### PR TITLE
Check if a file exists before trying to load it.

### DIFF
--- a/mnelab.py
+++ b/mnelab.py
@@ -147,11 +147,9 @@ class MainWindow(QMainWindow):
             File name.
         """
         if not exists(fname):
-            QMessageBox.critical(self, "File not found.",
-                                 "This file does not exist in this location:\n"
-                                 "{fname}\n"
-                                 "Has it been renamed or moved?"
-                                 .format(fname=fname))
+            QMessageBox.critical(self, "File not found",
+                                 "{} does not exist.".format(fname))
+            self._remove_recent(fname)
             return
         name, ext = splitext(split(fname)[-1])
         raw = None
@@ -488,6 +486,20 @@ class MainWindow(QMainWindow):
         self._write_settings()
         if not self.recent_menu.isEnabled():
             self.recent_menu.setEnabled(True)
+
+    def _remove_recent(self, fname):
+        """Remove file from recent file list.
+
+        Parameters
+        ----------
+        fname : str
+            File name.
+        """
+        if fname in self.recent:
+            self.recent.remove(fname)
+            self._write_settings()
+            if not self.recent:
+                self.recent_menu.setEnabled(False)
 
     def _write_settings(self):
         """Write application settings.

--- a/mnelab.py
+++ b/mnelab.py
@@ -1,6 +1,6 @@
 import sys
 from collections import Counter
-from os.path import getsize, join, split, splitext
+from os.path import exists, getsize, join, split, splitext
 
 import matplotlib
 import mne
@@ -146,7 +146,13 @@ class MainWindow(QMainWindow):
         fname : str
             File name.
         """
-        # TODO: check if fname exists
+        if not exists(fname):
+            QMessageBox.critical(self, "File not found.",
+                                 "This file does not exist in this location:\n"
+                                 "{fname}\n"
+                                 "Has it been renamed or moved?"
+                                 .format(fname=fname))
+            return
         name, ext = splitext(split(fname)[-1])
         raw = None
         if ext in ['.edf', '.bdf']:
@@ -158,7 +164,7 @@ class MainWindow(QMainWindow):
             raw = mne.io.read_raw_brainvision(fname, preload=True)
             self.history.append("raw = mne.io.read_raw_brainvision('{}', "
                                 "preload=True)".format(fname))
-        
+
         self.all.insert_data(DataSet(name=name, fname=fname,
                                      ftype=ext[1:].upper(), raw=raw))
         self.find_events()


### PR DESCRIPTION
If the user attempts to load a file which is not there, show a critical
QMessageBox with a short message and the full expected filepath.  For example,
this code will run if  a user tries to load a file from the
'Open recent' menu which has been renamed or moved.

If the file doesn't exist, return immediately.

TODO: Log an error here.