### PR TITLE
WIP: Improve the dialog for picking bad channels.

### DIFF
--- a/dialogs/Resources/UI/pickbadchannelsdialog.ui
+++ b/dialogs/Resources/UI/pickbadchannelsdialog.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>636</width>
+    <height>510</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Bad Channel Picker Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QListWidget" name="goodListWidget"/>
+   </item>
+   <item row="1" column="2">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QPushButton" name="moveToBadButton">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="moveToGoodButton">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="3">
+    <widget class="QListWidget" name="badListWidget"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Good Channels</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Bad Channels</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/dialogs/pickbadchannelsdialog.py
+++ b/dialogs/pickbadchannelsdialog.py
@@ -1,0 +1,50 @@
+from PyQt5.QtWidgets import QDialog, QListWidget, QStyle
+
+from .ui_pickbadchannelsdialog import Ui_Dialog
+
+
+class PickBadChannelsDialog(QDialog):
+    def __init__(self, parent, channels, bads=None):
+        super().__init__()
+        self.channels = channels
+        if not bads:
+            self.bads = []
+        else:
+            self.bads = bads
+        self.ui = Ui_Dialog()
+        self.ui.setupUi(self)
+
+        # populate lists
+        self.ui.goodListWidget.setSelectionMode(QListWidget.ExtendedSelection)
+        self.ui.badListWidget.setSelectionMode(QListWidget.ExtendedSelection)
+        self.ui.goodListWidget.insertItems(0, [chan for chan in channels if chan not in bads])
+        self.ui.badListWidget.insertItems(0, bads)
+
+        # icons
+        self.ui.moveToBadButton.setIcon(
+            self.style().standardIcon(QStyle.SP_ArrowRight))
+        self.ui.moveToGoodButton.setIcon(
+            self.style().standardIcon(QStyle.SP_ArrowLeft))
+
+        # connect buttons
+        self.ui.moveToBadButton.clicked.connect(self.moveToBads)
+        self.ui.moveToGoodButton.clicked.connect(self.moveToGoods)
+
+    def moveToBads(self):
+        indexes = self.ui.goodListWidget.selectedIndexes()
+        # record which rows are selected in reverse order, so popping them
+        # doesn't shift the indices downstream
+        rows = sorted((index.row() for index in indexes), reverse=True)
+        # pop the item in each of those rows
+        items_to_move = [self.ui.goodListWidget.takeItem(row) for row in rows]
+        # add the items back in re-reversed order so they show up in the order
+        # they appeared originally
+        self.ui.badListWidget.addItems(
+            reversed([item.text() for item in items_to_move]))
+
+    def moveToGoods(self):
+        indexes = self.ui.badListWidget.selectedIndexes()
+        rows = sorted((index.row() for index in indexes), reverse=True)
+        items_to_move = [self.ui.badListWidget.takeItem(row) for row in rows]
+        self.ui.goodListWidget.addItems(
+            reversed([item.text() for item in items_to_move]))

--- a/dialogs/ui_pickbadchannelsdialog.py
+++ b/dialogs/ui_pickbadchannelsdialog.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file 'Resources/UI/pickbadchannelsdialog.ui'
+#
+# Created by: PyQt5 UI code generator 5.9
+#
+# WARNING! All changes made in this file will be lost!
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+class Ui_Dialog(object):
+    def setupUi(self, Dialog):
+        Dialog.setObjectName("Dialog")
+        Dialog.resize(636, 510)
+        self.gridLayout = QtWidgets.QGridLayout(Dialog)
+        self.gridLayout.setObjectName("gridLayout")
+        self.horizontalLayout = QtWidgets.QHBoxLayout()
+        self.horizontalLayout.setObjectName("horizontalLayout")
+        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        self.horizontalLayout.addItem(spacerItem)
+        self.gridLayout.addLayout(self.horizontalLayout, 0, 1, 1, 2)
+        self.goodListWidget = QtWidgets.QListWidget(Dialog)
+        self.goodListWidget.setObjectName("goodListWidget")
+        self.gridLayout.addWidget(self.goodListWidget, 1, 0, 1, 2)
+        self.verticalLayout = QtWidgets.QVBoxLayout()
+        self.verticalLayout.setObjectName("verticalLayout")
+        self.moveToBadButton = QtWidgets.QPushButton(Dialog)
+        self.moveToBadButton.setText("")
+        self.moveToBadButton.setObjectName("moveToBadButton")
+        self.verticalLayout.addWidget(self.moveToBadButton)
+        self.moveToGoodButton = QtWidgets.QPushButton(Dialog)
+        self.moveToGoodButton.setText("")
+        self.moveToGoodButton.setObjectName("moveToGoodButton")
+        self.verticalLayout.addWidget(self.moveToGoodButton)
+        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        self.verticalLayout.addItem(spacerItem1)
+        self.gridLayout.addLayout(self.verticalLayout, 1, 2, 1, 1)
+        self.badListWidget = QtWidgets.QListWidget(Dialog)
+        self.badListWidget.setObjectName("badListWidget")
+        self.gridLayout.addWidget(self.badListWidget, 1, 3, 1, 1)
+        self.label = QtWidgets.QLabel(Dialog)
+        self.label.setObjectName("label")
+        self.gridLayout.addWidget(self.label, 0, 0, 1, 1)
+        self.label_2 = QtWidgets.QLabel(Dialog)
+        self.label_2.setObjectName("label_2")
+        self.gridLayout.addWidget(self.label_2, 0, 3, 1, 1)
+        self.buttonBox = QtWidgets.QDialogButtonBox(Dialog)
+        self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QtWidgets.QDialogButtonBox.Cancel|QtWidgets.QDialogButtonBox.Ok)
+        self.buttonBox.setObjectName("buttonBox")
+        self.gridLayout.addWidget(self.buttonBox, 2, 3, 1, 1)
+
+        self.retranslateUi(Dialog)
+        self.buttonBox.accepted.connect(Dialog.accept)
+        self.buttonBox.rejected.connect(Dialog.reject)
+        QtCore.QMetaObject.connectSlotsByName(Dialog)
+
+    def retranslateUi(self, Dialog):
+        _translate = QtCore.QCoreApplication.translate
+        Dialog.setWindowTitle(_translate("Dialog", "Bad Channel Picker Dialog"))
+        self.label.setText(_translate("Dialog", "Good Channels"))
+        self.label_2.setText(_translate("Dialog", "Bad Channels"))
+

--- a/mnelab.py
+++ b/mnelab.py
@@ -17,6 +17,7 @@ from mne.io.pick import channel_type
 
 from dialogs.filterdialog import FilterDialog
 from dialogs.pickchannelsdialog import PickChannelsDialog
+from dialogs.pickbadchannelsdialog import PickBadChannelsDialog
 from dialogs.referencedialog import ReferenceDialog
 from dialogs.montagedialog import MontageDialog
 from utils.datasets import DataSets, DataSet
@@ -364,12 +365,13 @@ class MainWindow(QMainWindow):
         """Set bad channels.
         """
         channels = self.all.current.raw.info["ch_names"]
-        selected = self.all.current.raw.info["bads"]
-        dialog = PickChannelsDialog(self, channels, selected, "Bad channels")
+        bads = self.all.current.raw.info["bads"]
+        dialog = PickBadChannelsDialog(self, channels, bads)
         if dialog.exec_():
-            bads = [item.data(0) for item in dialog.channels.selectedItems()]
+            bads = [item.data(0) for item in dialog.ui.badListWidget.findItems("", Qt.MatchContains)]
             self.all.current.raw.info["bads"] = bads
             self.all.data[self.all.index].raw.info["bads"] = bads
+            self.history.append("raw.info['bads'] = {}".format(bads))
             self._toggle_actions(True)
 
     def set_montage(self):


### PR DESCRIPTION
Currently, the channel picker dialog does a good job of allowing the user to
choose bad channels, but has a few shortcomings:

(1) It's difficult to see, at a glance, which channels have already been marked
as bad.

(2) When the user begins clicking on new channels to mark as bad, any
previously marked channels become unselected. Thus, making sure you've selected
everything you want requires careful scrolling.

Using two list widgets to shuffle channels goes some lengths to solve both
these issues.