### PR TITLE
Fix montage crash

### DIFF
--- a/dialogs/montagedialog.py
+++ b/dialogs/montagedialog.py
@@ -1,6 +1,7 @@
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QListWidget, QDialogButtonBox
 from PyQt5.QtCore import pyqtSlot
 
+
 class MontageDialog(QDialog):
     def __init__(self, parent, montages, selected=None):
         super().__init__(parent)

--- a/mnelab.py
+++ b/mnelab.py
@@ -388,7 +388,7 @@ class MainWindow(QMainWindow):
             self.all.current.montage = name
             self.all.data[self.all.index].montage = name
             montage = mne.channels.read_montage(name)
-            try: 
+            try:
                 self.all.current.raw.set_montage(montage)
                 self.all.data[self.all.index].raw.set_montage(montage)
                 self._update_infowidget()

--- a/mnelab.py
+++ b/mnelab.py
@@ -388,10 +388,13 @@ class MainWindow(QMainWindow):
             self.all.current.montage = name
             self.all.data[self.all.index].montage = name
             montage = mne.channels.read_montage(name)
-            self.all.current.raw.set_montage(montage)
-            self.all.data[self.all.index].raw.set_montage(montage)
-            self._update_infowidget()
-            self._toggle_actions()
+            try: 
+                self.all.current.raw.set_montage(montage)
+                self.all.data[self.all.index].raw.set_montage(montage)
+                self._update_infowidget()
+                self._toggle_actions()
+            except ValueError as v:
+                print(v)
 
     def plot_raw(self):
         """Plot raw data.
@@ -428,7 +431,10 @@ class MainWindow(QMainWindow):
 
     def plot_montage(self):
         montage = mne.channels.read_montage(self.all.current.montage)
-        montage.plot(kind="topomap")
+        if int(mne.__version__.split('.')[1]) >= 15:
+            montage.plot(kind="topomap")
+        else:
+            montage.plot()
 
     def load_ica(self):
         """Load ICA solution from a file.


### PR DESCRIPTION
Fix two crashes in the montage workflow + a few flake8 fixes.

This fix introduces the issue that, between differing versions of mne, the `Montage.plot()` function creates entirely different plots.  I'll see if I can come up with an elegant way to combine the setting and the viewing of the montages.  This might be a useful feature for someone who didn't know which montage they needed to use, but could figure it out through looking at the configuration and lining up the channel names. (esp. those who are entirely new to EEG)  

Also TODO: allow the user to load their own montage into the selection menu from a file.