### PR TITLE
[WIP] Support for XDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Optional dependencies provide additional features if installed:
 - [scikit-learn]() (ICA computation via FastICA)
 - [python-picard](https://pierreablin.github.io/picard/) (ICA computation via PICARD)
 - [pyEDFlib](https://github.com/holgern/pyedflib) (export raw to EDF/BDF)
+- [pyxdf](https://github.com/xdf-modules/xdf-Python) (import XDF files)
 
 In general, it is recommended to always use the latest package versions.
 
@@ -30,6 +31,7 @@ In general, it is recommended to always use the latest package versions.
 MNELAB comes with the following features that are not available in MNE:
 - Export raw to EDF/BDF (requires [pyEDFlib](https://github.com/holgern/pyedflib))
 - Export raw to EEGLAB SET
+- Import [XDF](https://github.com/sccn/xdf/wiki/Specifications) files (requires [pyxdf](https://github.com/xdf-modules/xdf-Python))
 
 ### Installation
 A package on [PyPI](https://pypi.python.org/pypi) and a stand-alone installer will be available soon.

--- a/mnelab/dialogs/channelpropertiesdialog.py
+++ b/mnelab/dialogs/channelpropertiesdialog.py
@@ -57,9 +57,9 @@ class ChannelPropertiesDialog(QDialog):
         self.buttonbox.accepted.connect(self.accept)
         self.buttonbox.rejected.connect(self.reject)
 
-        self.resize(500, 650)
-        self.view.setColumnWidth(0, 75)
-        self.view.setColumnWidth(1, 150)
+        self.resize(475, 650)
+        self.view.setColumnWidth(0, 70)
+        self.view.setColumnWidth(1, 155)
         self.view.setColumnWidth(2, 90)
 
 

--- a/mnelab/dialogs/xdfstreamsdialog.py
+++ b/mnelab/dialogs/xdfstreamsdialog.py
@@ -1,0 +1,50 @@
+from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QDialogButtonBox,
+                             QAbstractItemView, QTableView)
+from PyQt5.QtGui import QStandardItemModel, QStandardItem
+from PyQt5.QtCore import Qt
+
+
+class XDFStreamsDialog(QDialog):
+    def __init__(self, parent, rows, selected=None, disabled=None):
+        super().__init__(parent)
+        self.setWindowTitle("XDF Streams")
+
+        self.model = QStandardItemModel()
+        self.model.setHorizontalHeaderLabels(["ID", "Name", "Type", "Channels",
+                                              "Format", "Sampling Rate"])
+
+        for index, stream in enumerate(rows):
+            items = []
+            for item in stream:
+                tmp = QStandardItem()
+                tmp.setData(item, Qt.DisplayRole)
+                items.append(tmp)
+            for item in items:
+                item.setEditable(False)
+                if disabled is not None and index in disabled:
+                    item.setFlags(Qt.NoItemFlags)
+            self.model.appendRow(items)
+
+        self.view = QTableView()
+        self.view.setModel(self.model)
+        self.view.verticalHeader().setVisible(False)
+        self.view.horizontalHeader().setStretchLastSection(True)
+        self.view.setShowGrid(False)
+        self.view.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.view.setSortingEnabled(True)
+        self.view.sortByColumn(0, Qt.AscendingOrder)
+        self.view.selectRow(selected if selected is not None else 0)
+
+        vbox = QVBoxLayout(self)
+        vbox.addWidget(self.view)
+        self.buttonbox = QDialogButtonBox(QDialogButtonBox.Ok |
+                                          QDialogButtonBox.Cancel)
+        vbox.addWidget(self.buttonbox)
+        self.buttonbox.accepted.connect(self.accept)
+        self.buttonbox.rejected.connect(self.reject)
+
+        self.resize(750, 650)
+        self.view.setColumnWidth(0, 70)
+        self.view.setColumnWidth(1, 200)
+        self.view.setColumnWidth(2, 120)

--- a/mnelab/dialogs/xdfstreamsdialog.py
+++ b/mnelab/dialogs/xdfstreamsdialog.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import Qt
 class XDFStreamsDialog(QDialog):
     def __init__(self, parent, rows, selected=None, disabled=None):
         super().__init__(parent)
-        self.setWindowTitle("XDF Streams")
+        self.setWindowTitle("Select XDF Stream")
 
         self.model = QStandardItemModel()
         self.model.setHorizontalHeaderLabels(["ID", "Name", "Type", "Channels",
@@ -32,9 +32,10 @@ class XDFStreamsDialog(QDialog):
         self.view.setShowGrid(False)
         self.view.setSelectionMode(QAbstractItemView.SingleSelection)
         self.view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        if selected is not None:
+            self.view.selectRow(selected)
         self.view.setSortingEnabled(True)
         self.view.sortByColumn(0, Qt.AscendingOrder)
-        self.view.selectRow(selected if selected is not None else 0)
 
         vbox = QVBoxLayout(self)
         vbox.addWidget(self.view)

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -95,9 +95,7 @@ class MainWindow(QMainWindow):
         # initialize menus
         file_menu = self.menuBar().addMenu("&File")
         self.actions["open_file"] = file_menu.addAction(
-            "&Open...",
-            lambda: self.open_file(model.load, "Open raw", SUPPORTED_FORMATS),
-            QKeySequence.Open)
+            "&Open...", self.open_raw, QKeySequence.Open)
         self.recent_menu = file_menu.addMenu("Open recent")
         self.recent_menu.aboutToShow.connect(self._update_recent_menu)
         self.recent_menu.triggered.connect(self._load_recent)
@@ -275,6 +273,13 @@ class MainWindow(QMainWindow):
         # add to recent files
         if len(self.model) > 0:
             self._add_recent(self.model.current["fname"])
+
+    def open_raw(self):
+        """Open raw file."""
+        fname = QFileDialog.getOpenFileName(self, "Open raw",
+                                            filter=SUPPORTED_FORMATS)[0]
+        if fname:
+            self.model.load(fname)
 
     def open_file(self, f, text, ffilter):
         """Open file."""

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -24,7 +24,7 @@ from .dialogs.xdfstreamsdialog import XDFStreamsDialog
 from .widgets.infowidget import InfoWidget
 from .model import (SUPPORTED_FORMATS, SUPPORTED_EXPORT_FORMATS,
                     LabelsNotFoundError, InvalidAnnotationsError)
-from .utils.xdf import parse_xdf, parse_chunks
+from .utils import have, parse_xdf, parse_chunks
 
 
 __version__ = "0.1.0"
@@ -448,22 +448,8 @@ class MainWindow(QMainWindow):
 
     def run_ica(self):
         """Run ICA calculation."""
-        try:
-            import picard
-        except ImportError:
-            have_picard = False
-        else:
-            have_picard = True
-
-        try:
-            import sklearn  # required for FastICA
-        except ImportError:
-            have_sklearn = False
-        else:
-            have_sklearn = True
-
         dialog = RunICADialog(self, self.model.current["raw"].info["nchan"],
-                              have_picard, have_sklearn)
+                              have["picard"], have["sklearn"])
 
         if dialog.exec_():
             calc = CalcDialog(self, "Calculating ICA", "Calculating ICA.")

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -305,14 +305,9 @@ class MainWindow(QMainWindow):
                 dialog = XDFStreamsDialog(self, rows, selected=selected,
                                           disabled=disabled)
                 if dialog.exec_():
-                    # TODO: load selected stream of XDF file
                     row = dialog.view.selectionModel().selectedRows()[0].row()
-                    print(dialog.model.data(dialog.model.index(row, 0)),
-                          dialog.model.data(dialog.model.index(row, 1)),
-                          dialog.model.data(dialog.model.index(row, 2)),
-                          dialog.model.data(dialog.model.index(row, 3)),
-                          dialog.model.data(dialog.model.index(row, 4)),
-                          dialog.model.data(dialog.model.index(row, 5)))
+                    stream_id = dialog.model.data(dialog.model.index(row, 0))
+                    self.model.load(fname, stream_id=stream_id)
             else:  # all other file formats
                 self.model.load(fname)
 

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -277,10 +277,11 @@ class MainWindow(QMainWindow):
         if len(self.model) > 0:
             self._add_recent(self.model.current["fname"])
 
-    def open_raw(self):
+    def open_raw(self, fname=None):
         """Open raw file."""
-        fname = QFileDialog.getOpenFileName(self, "Open raw",
-                                            filter=SUPPORTED_FORMATS)[0]
+        if fname is None:
+            fname = QFileDialog.getOpenFileName(self, "Open raw",
+                                                filter=SUPPORTED_FORMATS)[0]
         if fname:
             name, ext = splitext(split(fname)[-1])
             ftype = ext[1:].upper()
@@ -611,7 +612,7 @@ class MainWindow(QMainWindow):
 
     @pyqtSlot(QAction)
     def _load_recent(self, action):
-        self.model.load(action.text())
+        self.open_raw(fname=action.text())
 
     @pyqtSlot()
     def _toggle_statusbar(self):

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -297,7 +297,13 @@ class MainWindow(QMainWindow):
                     if s["nominal_srate"] == 0:  # disable marker streams
                         disabled.append(idx)
 
-                dialog = XDFStreamsDialog(self, rows, disabled=disabled)
+                enabled = list(set(range(len(rows))) - set(disabled))
+                if enabled:
+                    selected = enabled[0]
+                else:
+                    selected = None
+                dialog = XDFStreamsDialog(self, rows, selected=selected,
+                                          disabled=disabled)
                 if dialog.exec_():
                     # TODO: load selected stream of XDF file
                     row = dialog.view.selectionModel().selectedRows()[0].row()

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -128,7 +128,7 @@ class Model:
             raw = mne.io.read_raw_eeglab(fname, preload=True)
             self.history.append(f"raw = mne.io.read_raw_eeglab('{fname}', "
                                 f"preload=True)")
-        elif ext in ["*.xdf"]:
+        elif ext in [".xdf"]:
             pass
 
         self.insert_data(defaultdict(lambda: None, name=name, fname=fname,

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -9,7 +9,7 @@ from scipy.io import savemat
 import mne
 
 
-SUPPORTED_FORMATS = "*.bdf *.edf *.gdf *.fif *.vhdr *.set"
+SUPPORTED_FORMATS = "*.bdf *.edf *.gdf *.fif *.vhdr *.set *.xdf"
 SUPPORTED_EXPORT_FORMATS = "*.fif *.set"
 try:
     import pyedflib
@@ -128,6 +128,8 @@ class Model:
             raw = mne.io.read_raw_eeglab(fname, preload=True)
             self.history.append(f"raw = mne.io.read_raw_eeglab('{fname}', "
                                 f"preload=True)")
+        elif ext in ["*.xdf"]:
+            pass
 
         self.insert_data(defaultdict(lambda: None, name=name, fname=fname,
                                      ftype=ftype, raw=raw))

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -8,17 +8,14 @@ from numpy.core.records import fromarrays
 from scipy.io import savemat
 import mne
 
-from .utils.xdf import read_raw_xdf
+from .utils import read_raw_xdf, have
 
 
-SUPPORTED_FORMATS = "*.bdf *.edf *.gdf *.fif *.vhdr *.set *.xdf"
+SUPPORTED_FORMATS = "*.bdf *.edf *.gdf *.fif *.vhdr *.set"
+if have["pyxdf"]:
+    SUPPORTED_FORMATS += " *.xdf"
 SUPPORTED_EXPORT_FORMATS = "*.fif *.set"
-try:
-    import pyedflib
-except ImportError:
-    have_pyedflib = False
-else:
-    have_pyedflib = True
+if have["pyedflib"]:
     SUPPORTED_EXPORT_FORMATS += " *.edf *.bdf"
 
 

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -8,6 +8,8 @@ from numpy.core.records import fromarrays
 from scipy.io import savemat
 import mne
 
+from .utils.xdf import read_raw_xdf
+
 
 SUPPORTED_FORMATS = "*.bdf *.edf *.gdf *.fif *.vhdr *.set *.xdf"
 SUPPORTED_EXPORT_FORMATS = "*.fif *.set"
@@ -105,7 +107,7 @@ class Model:
         return len(self.data)
 
     @data_changed
-    def load(self, fname):
+    def load(self, fname, *args, **kwargs):
         """Load data set from file."""
         name, ext = splitext(split(fname)[-1])
         ftype = ext[1:].upper()
@@ -113,26 +115,46 @@ class Model:
             raise ValueError(f"File format {ftype} is not supported.")
 
         if ext.lower() in [".edf", ".bdf", ".gdf"]:
-            raw = mne.io.read_raw_edf(fname, preload=True)
-            self.history.append(f"raw = mne.io.read_raw_edf('{fname}', "
-                                f"preload=True)")
+            raw = self._load_edf(fname)
         elif ext in [".fif"]:
-            raw = mne.io.read_raw_fif(fname, preload=True)
-            self.history.append(f"raw = mne.io.read_raw_fif('{fname}', "
-                                f"preload=True)")
+            raw = self._load_fif(fname)
         elif ext in [".vhdr"]:
-            raw = mne.io.read_raw_brainvision(fname, preload=True)
-            self.history.append(f"raw = mne.io.read_raw_brainvision('{fname}',"
-                                f" preload=True)")
+            raw = self._load_brainvision(fname)
         elif ext in [".set"]:
-            raw = mne.io.read_raw_eeglab(fname, preload=True)
-            self.history.append(f"raw = mne.io.read_raw_eeglab('{fname}', "
-                                f"preload=True)")
+            raw = self._load_eeglab(fname)
         elif ext in [".xdf"]:
-            pass
+            raw = self._load_xdf(fname, *args, **kwargs)
 
         self.insert_data(defaultdict(lambda: None, name=name, fname=fname,
                                      ftype=ftype, raw=raw))
+
+    def _load_edf(self, fname):
+        raw = mne.io.read_raw_edf(fname, preload=True)
+        self.history.append(f"raw = mne.io.read_raw_edf('{fname}', "
+                            f"preload=True)")
+        return raw
+
+    def _load_fif(self, fname):
+        raw = mne.io.read_raw_fif(fname, preload=True)
+        self.history.append(f"raw = mne.io.read_raw_fif('{fname}', "
+                            f"preload=True)")
+        return raw
+
+    def _load_brainvision(self, fname):
+        raw = mne.io.read_raw_brainvision(fname, preload=True)
+        self.history.append(f"raw = mne.io.read_raw_brainvision('{fname}',"
+                            f" preload=True)")
+        return raw
+
+    def _load_eeglab(self, fname):
+        raw = mne.io.read_raw_eeglab(fname, preload=True)
+        self.history.append(f"raw = mne.io.read_raw_eeglab('{fname}', "
+                            f"preload=True)")
+        return raw
+
+    def _load_xdf(self, fname, stream_id):
+        raw = read_raw_xdf(fname, stream_id=stream_id)
+        return raw
 
     @data_changed
     def find_events(self, stim_channel, consecutive=True, initial_event=True,

--- a/mnelab/utils/__init__.py
+++ b/mnelab/utils/__init__.py
@@ -1,1 +1,2 @@
-from .xdf import parse_xdf
+from .dependencies import have
+from .xdf import parse_xdf, parse_chunks, read_raw_xdf

--- a/mnelab/utils/__init__.py
+++ b/mnelab/utils/__init__.py
@@ -1,0 +1,1 @@
+from .xdf import parse_xdf

--- a/mnelab/utils/dependencies.py
+++ b/mnelab/utils/dependencies.py
@@ -1,0 +1,14 @@
+from importlib import import_module
+
+
+# deps contains information whether a specific package is available or not
+have = {d: False for d in ["numpy", "scipy", "mne", "matplotlib", "pyxdf",
+                           "pyedflib", "picard", "sklearn"]}
+
+for key, value in have.items():
+    try:
+        import_module(key)
+    except ModuleNotFoundError:
+        pass
+    else:
+        have[key] = True

--- a/mnelab/utils/dependencies.py
+++ b/mnelab/utils/dependencies.py
@@ -1,9 +1,9 @@
 from importlib import import_module
 
 
-# deps contains information whether a specific package is available or not
+# contains information whether a specific package is available or not
 have = {d: False for d in ["numpy", "scipy", "mne", "matplotlib", "pyxdf",
-                           "pyedflib", "picard", "sklearn"]}
+                           "pyedflib", "picard", "sklearn", "PyQt5"]}
 
 for key, value in have.items():
     try:

--- a/mnelab/utils/xdf.py
+++ b/mnelab/utils/xdf.py
@@ -1,0 +1,68 @@
+import struct
+import xml.etree.ElementTree as ET
+
+
+def parse_xdf(fname):
+    """Parse and return chunks contained in an XDF file.
+
+    Parameters
+    ----------
+    fname : str
+        Name of the XDF file.
+
+    Returns
+    -------
+    chunks : list
+        List of all chunks contained in the XDF file.
+    """
+    chunks = []
+    with open(fname, "rb") as f:
+        if f.read(4) != b"XDF:":  # magic code
+            raise ValueError(f"Invalid XDF file {fname}.")
+        for chunk in _read_chunks(f):
+            chunks.append(chunk)
+    return chunks
+
+
+def _read_chunks(f):
+    """Read and yield XDF chunks.
+
+    Parameters
+    ----------
+    f : file handle
+        File handle of XDF file.
+
+
+    Yields
+    ------
+    chunk : dict
+        XDF chunk.
+    """
+    while True:
+        chunk = dict()
+        try:
+            nbytes = struct.unpack("B", f.read(1))[0]
+        except struct.error:
+            return  # reached EOF
+        if nbytes == 1:
+            chunk["nbytes"] = struct.unpack("B", f.read(1))[0]
+        elif nbytes == 4:
+            chunk["nbytes"] = struct.unpack("<I", f.read(4))[0]
+        elif nbytes == 8:
+            chunk["nbytes"] = struct.unpack("<Q", f.read(8))[0]
+        chunk["tag"] = struct.unpack('<H', f.read(2))[0]
+        if chunk["tag"] in [2, 3, 4, 6]:
+            chunk["streamid"] = struct.unpack("<I", f.read(4))[0]
+            if chunk["tag"] == 2:  # parse StreamHeader chunk
+                xml = ET.fromstring(f.read(chunk["nbytes"] - 6).decode())
+                chunk = {**chunk, **_parse_streamheader(xml)}
+            else:  # skip remaining chunk contents
+                f.seek(chunk["nbytes"] - 6, 1)
+        else:
+            f.seek(chunk["nbytes"] - 2, 1)  # skip remaining chunk contents
+        yield chunk
+
+
+def _parse_streamheader(xml):
+    """Parse stream header XML."""
+    return {el.tag: el.text for el in xml if el.tag != "desc"}

--- a/mnelab/utils/xdf.py
+++ b/mnelab/utils/xdf.py
@@ -24,6 +24,20 @@ def parse_xdf(fname):
     return chunks
 
 
+def parse_chunks(chunks):
+    """Parse chunks and extract information on individual streams."""
+    streams = []
+    for chunk in chunks:
+        if chunk["tag"] == 2:  # stream header chunk
+            streams.append(dict(stream_id=chunk["stream_id"],
+                                name=chunk.get("name"),  # optional
+                                type=chunk.get("type"),  # optional
+                                channel_count=int(chunk["channel_count"]),
+                                channel_format=chunk["channel_format"],
+                                nominal_srate=int(chunk["nominal_srate"])))
+    return streams
+
+
 def _read_chunks(f):
     """Read and yield XDF chunks.
 
@@ -52,7 +66,7 @@ def _read_chunks(f):
             chunk["nbytes"] = struct.unpack("<Q", f.read(8))[0]
         chunk["tag"] = struct.unpack('<H', f.read(2))[0]
         if chunk["tag"] in [2, 3, 4, 6]:
-            chunk["streamid"] = struct.unpack("<I", f.read(4))[0]
+            chunk["stream_id"] = struct.unpack("<I", f.read(4))[0]
             if chunk["tag"] == 2:  # parse StreamHeader chunk
                 xml = ET.fromstring(f.read(chunk["nbytes"] - 6).decode())
                 chunk = {**chunk, **_parse_streamheader(xml)}


### PR DESCRIPTION
Prepare support for loading XDF files. Currently, XDF can't be loaded yet, but a dialog window shows a list of all available streams contained in the file. Marker streams (streams with fs=0Hz) are disabled. The plan is to load the selected stream (for now, only one stream can be selected and loaded). Marker streams will be imported as annotations.