### PR TITLE
Add show history dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased] - XXXX-XX-XX
 ### Added
 - Add option to interpolate bad channels ([#55](https://github.com/cbrnr/mnelab/pull/55) by [Victor Férat](https://github.com/vferat))
+- Add dialog to show the command history ([#58](https://github.com/cbrnr/mnelab/pull/57) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
 - Update view when all bads have been deselected in channel properties dialog (by [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/dialogs/historydialog.py
+++ b/mnelab/dialogs/historydialog.py
@@ -1,0 +1,18 @@
+from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QPlainTextEdit,
+                             QDialogButtonBox)
+
+
+class HistoryDialog(QDialog):
+    def __init__(self, parent, history):
+        super().__init__(parent=parent)
+        self.setWindowTitle("History")
+        layout = QVBoxLayout()
+        text = QPlainTextEdit()
+        text.setReadOnly(True)
+        text.setPlainText(history)
+        layout.addWidget(text)
+        buttonbox = QDialogButtonBox(QDialogButtonBox.Ok)
+        layout.addWidget(buttonbox)
+        self.setLayout(layout)
+        buttonbox.accepted.connect(self.accept)
+        self.resize(700, 500)

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -14,6 +14,7 @@ from PyQt5.QtWidgets import (QApplication, QMainWindow, QFileDialog, QSplitter,
 from mne.io.pick import channel_type
 
 from .dialogs.errormessagebox import ErrorMessageBox
+from .dialogs.historydialog import HistoryDialog
 from .dialogs.interpolatebadsdialog import InterpolateBadsDialog
 from .dialogs.annotationsdialog import AnnotationsDialog
 from .dialogs.filterdialog import FilterDialog
@@ -213,7 +214,9 @@ class MainWindow(QMainWindow):
             "Create Epochs...", self.epoch_data)
 
         view_menu = self.menuBar().addMenu("&View")
-        self.actions["statusbar"] = view_menu.addAction("Statusbar",
+        self.actions["history"] = view_menu.addAction("&History...",
+                                                      self.show_history)
+        self.actions["statusbar"] = view_menu.addAction("&Statusbar",
                                                         self._toggle_statusbar)
         self.actions["statusbar"].setCheckable(True)
 
@@ -651,6 +654,12 @@ class MainWindow(QMainWindow):
             else:
                 ref = [c.strip() for c in dialog.channellist.text().split(",")]
                 self.model.set_reference(ref)
+
+    def show_history(self):
+        """Show history."""
+        dialog = HistoryDialog(self, "\n".join(self.model.history))
+        dialog.exec_()
+
 
     def show_about(self):
         """Show About dialog."""


### PR DESCRIPTION
Fixes #38. This is a very basic implementation, in a future update line numbers could be added (see https://doc.qt.io/qt-5/qtwidgets-widgets-codeeditor-example.html).