### PR TITLE
Export annotations duration to BrainVision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Added
 - Add MNELAB logo to About dialog (by [Clemens Brunner](https://github.com/cbrnr))
 - Export data is split into submenus with a separate entry for each supported export format ([#66](https://github.com/cbrnr/mnelab/pull/66) by [Clemens Brunner](https://github.com/cbrnr))
-- Add support for exporting to BrainVision files ([#68](https://github.com/cbrnr/mnelab/pull/68) by [Clemens Brunner](https://github.com/cbrnr)) 
+- Add support for exporting to BrainVision files ([#68](https://github.com/cbrnr/mnelab/pull/68) and [#75](https://github.com/cbrnr/mnelab/pull/75) by [Clemens Brunner](https://github.com/cbrnr)) 
 
 ### Fixed
 - Correctly report file size for BrainVision data ([#69](https://github.com/cbrnr/mnelab/pull/69) by [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -312,18 +312,15 @@ class Model:
         data = self.current["data"].get_data()
         fs = self.current["data"].info["sfreq"]
         ch_names = self.current["data"].info["ch_names"]
-        if self.current["data"].info["meas_date"] is not None:
-            meas_date = self.current['data'].info["meas_date"][0]
-            meas_date = datetime.utcfromtimestamp(meas_date)
-        else:
-            meas_date = None
+        events = None
         if not isinstance(self.current["events"], np.ndarray):
-            events = mne.events_from_annotations(self.current["data"])[0]
-            events = events[:, [0, 2]]
+            if self.current["data"].annotations:
+                events = mne.events_from_annotations(self.current["data"])[0]
+                dur = self.current["data"].annotations.duration * fs
+                events = np.column_stack([events[:, [0, 2]], dur.astype(int)])
         else:
             events = self.current["events"][:, [0, 2]]
-        pybv.write_brainvision(data, fs, ch_names, name, head, events=events,
-                               meas_date=meas_date)
+        pybv.write_brainvision(data, fs, ch_names, name, head, events=events)
 
     def export_bads(self, fname):
         """Export bad channels info to a CSV file."""


### PR DESCRIPTION
Requires pybv >= 0.2.0. Furthermore, meas_date is not exported because it creates an additional marker in the .vmrk file (seems a better idea to me, but this can be reverted anytime if people feel it is needed).