### PR TITLE
Add version numbers for dependencies (instead of just True/False)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Correctly report file size for BrainVision data ([#69](https://github.com/cbrnr/mnelab/pull/69) by [Clemens Brunner](https://github.com/cbrnr))
 - Retain events when creating epochs ([#73](https://github.com/cbrnr/mnelab/pull/73) by [Clemens Brunner](https://github.com/cbrnr))
 
+### Changed
+- The internally used ``have`` dictionary now contains version numbers for existing modules ([#76](https://github.com/cbrnr/mnelab/pull/76) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [0.3.0] - 2019-08-13
 ### Added
 - Add option to interpolate bad channels ([#55](https://github.com/cbrnr/mnelab/pull/55) by [Victor Férat](https://github.com/vferat))

--- a/mnelab/utils/dependencies.py
+++ b/mnelab/utils/dependencies.py
@@ -11,8 +11,16 @@ have = {d: False for d in ["numpy", "scipy", "mne", "matplotlib", "pyxdf",
 
 for key, value in have.items():
     try:
-        import_module(key)
+        mod = import_module(key)
     except ModuleNotFoundError:
         pass
     else:
-        have[key] = True
+        try:
+            version = mod.__version__
+        except AttributeError:
+            if key == "PyQt5":
+                mod = import_module("PyQt5.QtCore")
+                version = mod.PYQT_VERSION_STR
+            else:
+                version = True  # no __version__ found but the module exists
+        have[key] = version


### PR DESCRIPTION
This extends the dict by setting the values to the package versions if they exist - if a package does not exist, the value remains `False`, e.g.:

```
{'PyQt5': '5.13.0',
 'matplotlib': '3.1.1',
 'mne': '0.19.dev0',
 'numpy': '1.17.1',
 'picard': False,
 'pybv': '0.2.0',
 'pyedflib': '0.1.14',
 'pyxdf': '1.15.2',
 'scipy': '1.3.1',
 'sklearn': '0.21.3'}
```