### PR TITLE
Disable string streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - Fixed dropping XDF files on MNELAB and loading XDF files without channel labels ([#86](https://github.com/cbrnr/mnelab/pull/86) by [Clemens Brunner](https://github.com/cbrnr))
+- Disable XDF streams of type string in selection dialog ([#90](https://github.com/cbrnr/mnelab/pull/90) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.4.0] - 2019-09-04
 ### Added

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -384,7 +384,9 @@ class MainWindow(QMainWindow):
                     rows.append([s["stream_id"], s["name"], s["type"],
                                  s["channel_count"], s["channel_format"],
                                  s["nominal_srate"]])
-                    if s["nominal_srate"] == 0:  # disable marker streams
+                    is_marker = (s["nominal_srate"] == 0 or
+                                 s["channel_format"] == "string")
+                    if is_marker:  # disable marker streams
                         disabled.append(idx)
 
                 enabled = list(set(range(len(rows))) - set(disabled))


### PR DESCRIPTION
Previously, only streams with a `nominal_srate` were disabled in the XDF stream selection dialog because we want to treat these as annotations. This PR also disables streams of type string even if these are regularly sampled (we should still treat them as annotations or convert to a numeric type, but this is something for later).