### PR TITLE
Remove bdist_wheel because of macOS-only dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.1] - 2019-10-24
+### Fixed
+- Remove binary wheel on PyPI because of a macOS-only package dependency
+
 ## [0.5.0] - 2019-10-23
 ### Added
 - MNELAB is now shown as an app name in the menu bar on macOS ([#83](https://github.com/cbrnr/mnelab/pull/83) by [Clemens Brunner](https://github.com/cbrnr))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.5.1] - 2019-10-24
 ### Fixed
-- Remove binary wheel on PyPI because of a macOS-only package dependency
+- Remove binary wheel on PyPI because of a macOS-only package dependency ([#95](https://github.com/cbrnr/mnelab/pull/95) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.5.0] - 2019-10-23
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Follow these steps to make a new [PyPI](https://pypi.org/project/mnelab/) releas
 - Update the section in `CHANGELOG.md` corresponding to the new release with the current date
 - Commit these changes and push
 - Create a new release on GitHub and use the version as the tag name (make sure to prepend the version with a `v`)
-- Generate the source and binary wheels with `python3 setup.py sdist bdist_wheel` (remove the folders `build`, `dist`, and `mnelab.egg-info` before if these already exist)
+- Generate the source and binary wheels with `python3 setup.py sdist` (remove the folders `build`, `dist`, and `mnelab.egg-info` before if these already exist)
 - Upload to PyPI with `twine upload dist/*`
 
 This concludes the new release. Now prepare the source for the next planned release as follows:

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -34,7 +34,7 @@ from .utils import (IMPORT_FORMATS, EXPORT_FORMATS, have, split_fname,
 import mnelab.resources  # noqa
 
 
-__version__ = "0.6.0.dev0"
+__version__ = "0.5.1"
 
 MAX_RECENT = 6  # maximum number of recent files
 


### PR DESCRIPTION
sdist should work on all platforms because MNELAB is pure Python anyways.