### PR TITLE
Add alternative conda installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,24 @@ mnelab
 ```
 The `mnelab` command in the last line starts the application. Any issues with this conda package should be reported to the respective [issue tracker](https://github.com/conda-forge/mnelab-feedstock/issues).
 
+Alternatively, if for some reason you do not want to use conda-forge, you can first install all dependencies that are present in the default conda channel:
+```
+conda install pyqt numpy scipy matplotlib
+```
+Next, install the dependencies that are not in the default conda channel via pip:
+```
+pip install mne
+```
+Finally, install MNELAB as follows:
+```
+pip install --no-deps mnelab
+```
+
 #### Arch Linux
 If you use [Arch Linux](https://www.archlinux.org/), you can install the [python-mnelab](https://aur.archlinux.org/packages/python-mnelab/) AUR package (note that this requires the [python-mne](https://aur.archlinux.org/packages/python-mne/) AUR package).
 
-
 #### Standalone installer
 A stand-alone installer will be available soon.
-
 
 #### Development version
 Follow these steps to use the latest development version of MNELAB:


### PR DESCRIPTION
In case people want to stick with the default channel this method also works.