### PR TITLE
Simplify setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Fix blurry icons on macOS HiDPI screens ([#102](https://github.com/cbrnr/mnelab/pull/102) by [Clemens Brunner](https://github.com/cbrnr))
 
+### Changed
+- Use environment markers in `setup.py` for `install_requires` ([#105](https://github.com/cbrnr/mnelab/pull/105) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [0.5.2] - 2019-10-30
 ### Fixed
 - Fix multiprocessing runtime error (context has already been set) ([#98](https://github.com/cbrnr/mnelab/pull/98) by [Clemens Brunner](https://github.com/cbrnr)) 

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,6 @@ with open(path.join('mnelab', 'mainwindow.py'), 'r') as f:
             version = line.split('=')[1].strip().strip('"')
             break
 
-
-install_requires = ['mne', 'numpy', 'scipy', 'matplotlib', 'PyQt5']
-if sys.platform.startswith("darwin"):
-    install_requires.append('pyobjc-framework-Cocoa')
-
 setup(
     name='mnelab',
     version=version,
@@ -46,7 +41,8 @@ setup(
     keywords='EEG MEG MNE GUI electrophysiology',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     python_requires='>=3.6, <4',
-    install_requires=install_requires,
+    install_requires=['mne', 'numpy', 'scipy', 'matplotlib', 'PyQt5',
+                      'pyobjc-framework-Cocoa;platform_system=="Darwin"'],
     extras_require={"EDF export": ["pyedflib"],
                     "PICARD": ["python-picard"],
                     "FastICA": ["scikit-learn"],


### PR DESCRIPTION
`install_requires` can make use of environment markers, so this makes the module a bit shorter.