### PR TITLE
ENH: Always run via framework build on macOS conda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 ### Fixed
 - Fix blurry icons on macOS HiDPI screens ([#102](https://github.com/cbrnr/mnelab/pull/102) by [Clemens Brunner](https://github.com/cbrnr))
 - Use `mne.channels.make_standard_montage` instead of deprecated `mne.channels.read_montage` ([#107](https://github.com/cbrnr/mnelab/pull/107) by [Clemens Brunner](https://github.com/cbrnr))
+- Ensure MNELAB is run using a "framework build" of Python on `conda` installations on macOS ([#119](https://github.com/cbrnr/mnelab/pull/119) by [Richard Höchenberger](https://github.com/hoechenberger))
 
 ### Changed
 - Use environment markers in `setup.py` for `install_requires` ([#105](https://github.com/cbrnr/mnelab/pull/105) by [Clemens Brunner](https://github.com/cbrnr))
 - Bump required minimum MNE version to 0.19 ([#107](https://github.com/cbrnr/mnelab/pull/107) by [Clemens Brunner](https://github.com/cbrnr))
+- Spawn ICA process pool via `Pebble` instead of `multiprocessing` to avoid Python segfaulting on macOS `conda` installations ([#119](https://github.com/cbrnr/mnelab/pull/119) by [Richard Höchenberger](https://github.com/hoechenberger))
 
 ## [0.5.2] - 2019-10-30
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ MNELAB requires Python >= 3.6. In addition, the following Python packages are re
 - [PyQt5](https://www.riverbankcomputing.com/software/pyqt/download5) >= 5.10.0
 - [numpy](http://www.numpy.org/) >= 1.14.0
 - [scipy](https://www.scipy.org/scipylib/index.html) >= 1.0.0
+- [Pebble](https://pebble.readthedocs.io/)
 - [matplotlib](https://matplotlib.org/) >= 2.0.0
 - [mne](https://github.com/mne-tools/mne-python) >= 0.19.0
 - [pyobjc-framework-Cocoa](https://pyobjc.readthedocs.io/en/latest/) >= 5.2.0 (macOS only)

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -3,6 +3,7 @@
 # License: BSD (3-clause)
 
 import sys
+import os
 import matplotlib
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import Qt
@@ -10,7 +11,7 @@ from PyQt5.QtCore import Qt
 from mnelab import MainWindow, Model
 
 
-def main():
+def _run():
     app_name = "MNELAB"
     if sys.platform.startswith("darwin"):
         try:  # set bundle name on macOS (app name shown in the menu bar)
@@ -37,6 +38,36 @@ def main():
             model.load(f)
     model.view.show()
     sys.exit(app.exec_())
+
+
+def _run_pythonw():
+    """Execute this script again through pythonw.
+
+    This ensures we're using a framework build of Python on macOS.
+    """
+    cmd = [sys.executable + "w", __file__]  # pythonw executable
+
+    # Append command line arguments.
+    if len(sys.argv) > 1:
+        cmd.append(*sys.argv[1:])
+
+    env = os.environ.copy()
+    env["MNELAB_RUNNING_PYTHONW"] = "True"
+
+    import subprocess
+    subprocess.run(cmd, env=env)
+    sys.exit()
+
+
+def main():
+    # Ensure we're always using a "framework build" on macOS.
+    _MACOS_CONDA = sys.platform == "darwin" and "CONDA_PREFIX" in os.environ
+    _RUNNING_PYTHONW = "MNELAB_RUNNING_PYTHONW" in os.environ
+
+    if _MACOS_CONDA and not _RUNNING_PYTHONW:
+        _run_pythonw()
+    else:
+        _run()
 
 
 if __name__ == "__main__":

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -49,7 +49,7 @@ def _run_pythonw():
     import subprocess
 
     cwd = pathlib.Path.cwd()
-    python_path = pathlib.Path(sys.executable).parent / 'pythonw'
+    python_path = pathlib.Path(sys.exec_prefix) / 'pythonw'
 
     if not python_path.exists():
         msg = ('pythonw executable not found. '

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -6,7 +6,7 @@ import sys
 import os
 import matplotlib
 from PyQt5.QtWidgets import QApplication
-from PyQt5.QtCore import Qt, QProcess, QProcessEnvironment
+from PyQt5.QtCore import Qt
 
 from mnelab import MainWindow, Model
 
@@ -56,28 +56,17 @@ def _run_pythonw():
                'Please install python.app via conda.')
         raise RuntimeError(msg)
 
-    cmd = [str(python_path), '-m', 'mnelab']
+    cmd = [python_path, '-m', 'mnelab']
 
     # Append command line arguments.
     if len(sys.argv) > 1:
-        cmd.extend(sys.argv[1:])
+        cmd.append(*sys.argv[1:])
 
     env = os.environ.copy()
     env["MNELAB_RUNNING_PYTHONW"] = "True"
 
-    # subprocess.run(cmd, env=env, cwd=cwd)
-    proc = subprocess.Popen(cmd, env=env, cwd=cwd, start_new_session=True)
-    # proc.communicate()
-
-    # env = QProcessEnvironment.systemEnvironment()
-    # env.insert("MNELAB_RUNNING_PYTHONW", "True")
-    # p = QProcess()
-    # p.setProcessEnvironment(env)
-    # p.setWorkingDirectory(str(cwd))
-    # p.start(' '.join(cmd))
-    # p.waitForFinished()
-    # sys.exit()
-    print('foo!')
+    subprocess.run(cmd, env=env, cwd=cwd)
+    sys.exit()
 
 
 def main():

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -49,7 +49,7 @@ def _run_pythonw():
     import subprocess
 
     cwd = pathlib.Path.cwd()
-    python_path = pathlib.Path(sys.exec_prefix) / 'pythonw'
+    python_path = pathlib.Path(sys.exec_prefix) / 'bin' / 'pythonw'
 
     if not python_path.exists():
         msg = ('pythonw executable not found. '

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -45,7 +45,18 @@ def _run_pythonw():
 
     This ensures we're using a framework build of Python on macOS.
     """
-    cmd = [sys.executable + "w", __file__]  # pythonw executable
+    import pathlib
+    import subprocess
+
+    cwd = pathlib.Path.cwd()
+    python_path = pathlib.Path(sys.executable).parent / 'pythonw'
+
+    if not python_path.exists():
+        msg = ('pythonw executable not found. '
+               'Please install python.app via conda.')
+        raise RuntimeError(msg)
+
+    cmd = [python_path, '-m', 'mnelab']
 
     # Append command line arguments.
     if len(sys.argv) > 1:
@@ -54,8 +65,7 @@ def _run_pythonw():
     env = os.environ.copy()
     env["MNELAB_RUNNING_PYTHONW"] = "True"
 
-    import subprocess
-    subprocess.run(cmd, env=env)
+    subprocess.run(cmd, env=env, cwd=cwd)
     sys.exit()
 
 

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -4,6 +4,7 @@
 
 import sys
 import os
+import multiprocessing as mp
 import matplotlib
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import Qt
@@ -81,4 +82,5 @@ def main():
 
 
 if __name__ == "__main__":
+    mp.set_start_method("spawn", force=True)  # required for Linux/macOS
     main()

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -6,7 +6,7 @@ import sys
 import os
 import matplotlib
 from PyQt5.QtWidgets import QApplication
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QProcess, QProcessEnvironment
 
 from mnelab import MainWindow, Model
 
@@ -56,7 +56,7 @@ def _run_pythonw():
                'Please install python.app via conda.')
         raise RuntimeError(msg)
 
-    cmd = [python_path, '-m', 'mnelab']
+    cmd = [str(python_path), '-m', 'mnelab']
 
     # Append command line arguments.
     if len(sys.argv) > 1:
@@ -65,8 +65,19 @@ def _run_pythonw():
     env = os.environ.copy()
     env["MNELAB_RUNNING_PYTHONW"] = "True"
 
-    subprocess.run(cmd, env=env, cwd=cwd)
-    sys.exit()
+    # subprocess.run(cmd, env=env, cwd=cwd)
+    proc = subprocess.Popen(cmd, env=env, cwd=cwd, start_new_session=True)
+    # proc.communicate()
+
+    # env = QProcessEnvironment.systemEnvironment()
+    # env.insert("MNELAB_RUNNING_PYTHONW", "True")
+    # p = QProcess()
+    # p.setProcessEnvironment(env)
+    # p.setWorkingDirectory(str(cwd))
+    # p.start(' '.join(cmd))
+    # p.waitForFinished()
+    # sys.exit()
+    print('foo!')
 
 
 def main():

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -3,6 +3,8 @@
 # License: BSD (3-clause)
 
 import multiprocessing as mp
+mp.set_start_method("spawn", force=True)  # required for Linux/macOS
+import pebble
 from sys import version_info
 import traceback
 from os.path import isfile, isdir
@@ -88,9 +90,6 @@ class MainWindow(QMainWindow):
             sets. This decouples the GUI from the data (model/view).
         """
         super().__init__()
-
-        mp.set_start_method("spawn", force=True)  # required for Linux/macOS
-
         self.model = model  # data model
         self.setWindowTitle("MNELAB")
 
@@ -635,19 +634,26 @@ class MainWindow(QMainWindow):
             self.model.history.append(f"ica = mne.preprocessing.ICA("
                                       f"method={dialog.methods[method]}, "
                                       f"fit_params={fit_params})")
-            pool = mp.Pool(1)
+
             kwds = {"reject_by_annotation": exclude_bad_segments}
-            res = pool.apply_async(func=ica.fit,
-                                   args=(self.model.current["data"],),
-                                   kwds=kwds, callback=lambda x: calc.accept())
+            print(mp.get_start_method)
+            pool = pebble.ProcessPool(max_workers=1)
+            process = pool.schedule(function=ica.fit,
+                                    args=(self.model.current["data"],),
+                                    kwargs=kwds)
+            process.add_done_callback(lambda x: calc.accept())
+            pool.close()
+
             if not calc.exec_():
-                pool.terminate()
+                pool.stop()
+                pool.join()
             else:
-                self.model.current["ica"] = res.get(timeout=1)
+                self.model.current["ica"] = process.result()
                 self.model.history.append(f"ica.fit(inst=raw, "
                                           f"reject_by_annotation="
                                           f"{exclude_bad_segments})")
                 self.data_changed()
+                pool.join()
 
     def apply_ica(self):
         """Apply current fitted ICA."""

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -2,7 +2,6 @@
 #
 # License: BSD (3-clause)
 
-import multiprocessing as mp
 import pebble
 from sys import version_info
 import traceback
@@ -38,7 +37,6 @@ import mnelab.resources  # noqa
 __version__ = "0.6.0.dev0"
 
 MAX_RECENT = 6  # maximum number of recent files
-mp.set_start_method("spawn", force=True)  # required for Linux/macOS
 
 
 def read_settings():

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -3,7 +3,6 @@
 # License: BSD (3-clause)
 
 import multiprocessing as mp
-mp.set_start_method("spawn", force=True)  # required for Linux/macOS
 import pebble
 from sys import version_info
 import traceback
@@ -39,6 +38,7 @@ import mnelab.resources  # noqa
 __version__ = "0.6.0.dev0"
 
 MAX_RECENT = 6  # maximum number of recent files
+mp.set_start_method("spawn", force=True)  # required for Linux/macOS
 
 
 def read_settings():

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -636,7 +636,6 @@ class MainWindow(QMainWindow):
                                       f"fit_params={fit_params})")
 
             kwds = {"reject_by_annotation": exclude_bad_segments}
-            print(mp.get_start_method)
             pool = pebble.ProcessPool(max_workers=1)
             process = pool.schedule(function=ica.fit,
                                     args=(self.model.current["data"],),

--- a/requirements-oldest.txt
+++ b/requirements-oldest.txt
@@ -1,6 +1,7 @@
 PyQt5==5.10.0
 numpy==1.14.0
 scipy==1.0.0
+pebble
 matplotlib==2.0.0
 mne==0.19.0
 pyobjc-framework-Cocoa==5.2.0; sys_platform == "darwin"

--- a/requirements-oldest.txt
+++ b/requirements-oldest.txt
@@ -1,7 +1,7 @@
 PyQt5==5.10.0
 numpy==1.14.0
 scipy==1.0.0
-pebble
+pebble==4.5.0
 matplotlib==2.0.0
 mne==0.19.0
 pyobjc-framework-Cocoa==5.2.0; sys_platform == "darwin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 PyQt5
 numpy
 scipy
+pebble
 matplotlib
 mne
 pyobjc-framework-Cocoa; sys_platform == "darwin"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=['mne>=0.19',
                       'numpy>=1.14',
                       'scipy>=1.0',
-                      'pebble',
+                      'pebble>=4.5.0',
                       'matplotlib>=2.0',
                       'PyQt5>=5.10',
                       'pyobjc-framework-Cocoa>=5.2;platform_system=="Darwin"'],

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     install_requires=['mne>=0.19',
                       'numpy>=1.14',
                       'scipy>=1.0',
+                      'pebble',
                       'matplotlib>=2.0',
                       'PyQt5>=5.10',
                       'pyobjc-framework-Cocoa>=5.2;platform_system=="Darwin"'],


### PR DESCRIPTION
This PR ensures that we're always running MNELAB with a "framework build" of Python on macOS, if a `conda`-installed Python interpreter is used.

The way this works is the following:
- first, we check whether we're running macOS and in a `conda` environment (upon environment activation, the `CONDA_PREFIX` env variable is set)
- if that's not the case, run the application as usual
- otherwise, spawn a new `pythonw` process (i.e., a framework build) to execute `__main__.py` again, preserving all command line arguments that were initially passed, and set an environment variable `MNELAB_RUNNING_PYTHONW`, indicating we're now using the framework build
- now, when the newly spawned Python interpreter executes `__main__.py`, it will find that we're using a framework build, because the environment variable is set; and will proceed to start the application in the "usual" manner

We have to jump through these hoops bc there's no built-in way to determine whether Python was started as `pythonw`, so we introduce an environment variable and _always_ spawn a subprocess on macOS if we're using `conda`.

With this, both the `mnelab` entry point and `python -m mnelab` start up the application as the users would expect.