### PR TITLE
Accomodate changes to LabRecorder nominal srate

### DIFF
--- a/mnelab/utils/io.py
+++ b/mnelab/utils/io.py
@@ -229,7 +229,7 @@ def parse_chunks(chunks):
                                 hostname=chunk.get("hostname"),  # optional
                                 channel_count=int(chunk["channel_count"]),
                                 channel_format=chunk["channel_format"],
-                                nominal_srate=int(chunk["nominal_srate"])))
+                                nominal_srate=int(float(chunk["nominal_srate"]))))
     return streams
 
 

--- a/mnelab/utils/io.py
+++ b/mnelab/utils/io.py
@@ -229,7 +229,7 @@ def parse_chunks(chunks):
                                 hostname=chunk.get("hostname"),  # optional
                                 channel_count=int(chunk["channel_count"]),
                                 channel_format=chunk["channel_format"],
-                                nominal_srate=int(float(chunk["nominal_srate"]))))
+                                nominal_srate=float(chunk["nominal_srate"])))
     return streams
 
 


### PR DESCRIPTION
LabRecorder was modified so that the nominal sampling rate is now a string of a double rather than a string of an int. This is actually correct because the type in the lsl::info structure is in fact a double. This means that XDF files recorded with later versions of LabRecorder (unfortunately I couldn't track down the actual commit that made this change) will throw an error at line 232. This small change should prevent this and it should remain back compatible.