### PR TITLE
Correctly load BV files with ext other than .eeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Add support for appending continuous raw data ([#108](https://github.com/cbrnr/mnelab/pull/108) by [Lukas Stranger](https://github.com/stralu) and [Clemens Brunner](https://github.com/cbrnr))
 - Add support for appending epoched data ([#135](https://github.com/cbrnr/mnelab/pull/135) by [Lukas Stranger](https://github.com/stralu))
 
+### Fixed
+- Fix loading of BrainVision files that have an extension other than .eeg ([#142](https://github.com/cbrnr/mnelab/pull/142) by [Clemens Brunner](https://github.com/cbrnr))
+
 ### Changed
 - Use [QtPy](https://github.com/spyder-ide/qtpy) to support both PyQt5 and PySide2 ([#118](https://github.com/cbrnr/mnelab/pull/118) by [Clemens Brunner](https://github.com/cbrnr))
 - Remove resource file and include icons directly ([#125](https://github.com/cbrnr/mnelab/pull/125) by [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -140,7 +140,7 @@ class Model:
             raise UnknownFileTypeError(f"Unknown file type for {fname}.")
 
         if ext == ".vhdr":
-            fsize = getsize(join(split(fname)[0], name + ".eeg")) / 1024 ** 2
+            fsize = getsize(data.filenames[0]) / 1024 ** 2
         else:
             fsize = getsize(fname) / 1024 ** 2
 


### PR DESCRIPTION
MNELAB crashed if the BrainVision data file extension was not `.eeg`. However, the data file name is specified in the `.vhdr` file and can have an arbitrary extension (usually it is either `.eeg` or `.dat`). This PR resolves this issue.