### PR TITLE
Correctly enable/disable writers for epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Add support for automatic light/dark mode switching on macOS ([#152](https://github.com/cbrnr/mnelab/pull/152) by [Clemens Brunner](https://github.com/cbrnr))
 
+### Fixed
+- Fix bug that prevented exporting data ([#156](https://github.com/cbrnr/mnelab/pull/156) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [0.5.5] - 2020-06-03
 ### Added
 - Add support for appending continuous raw data ([#108](https://github.com/cbrnr/mnelab/pull/108) by [Lukas Stranger](https://github.com/stralu) and [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -109,19 +109,23 @@ def write_bv(fname, raw, events=None):
 
 
 # supported write file formats
-writers = {".fif": [write_fif, "Elekta Neuromag"],
-           ".fif.gz": [write_fif, "Elekta Neuromag"],
-           ".set": [write_set, "EEGLAB"]}
+# this dict contains each supported file extension as a key
+# the corresponding value is a list with three elements: (1) the writer
+# function, (2) the full file format name, and (3) a (comma-separated) string
+# indicating the supported objects (currently either raw or epoch)
+writers = {".fif": [write_fif, "Elekta Neuromag", "raw,epoch"],
+           ".fif.gz": [write_fif, "Elekta Neuromag", "raw,epoch"],
+           ".set": [write_set, "EEGLAB", "raw"]}
 if have["pybv"]:
-    writers.update({".eeg": [write_bv, "BrainVision"]})
+    writers.update({".eeg": [write_bv, "BrainVision", "raw"]})
 if have["pyedflib"]:
-    writers.update({".edf": [write_edf, "European Data Format"],
-                    ".bdf": [write_edf, "Biosemi Data Format"]})
+    writers.update({".edf": [write_edf, "European Data Format", "raw"],
+                    ".bdf": [write_edf, "Biosemi Data Format", "raw"]})
 
 
 def write_raw(fname, raw):
     ext = "".join(Path(fname).suffixes)
     if ext in writers:
-        writers[ext](fname, raw)
+        writers[ext][0](fname, raw)
     else:
         raise ValueError(f"Unknown file type {ext}.")

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -390,6 +390,14 @@ class MainWindow(QMainWindow):
             self.actions["convert_bl"].setEnabled(
                     len(mne.pick_types(self.model.current["data"].info,
                         fnirs="fnirs_od")))
+            # disable unsupported exporters for epochs (all must support raw)
+            if self.model.current["dtype"] == "epochs":
+                for ext, description in writers.items():
+                    action = "export_data" + ext.replace(".", "_")
+                    if "epoch" in description[2]:
+                        self.actions[action].setEnabled(True)
+                    else:
+                        self.actions[action].setEnabled(False)
         # add to recent files
         if len(self.model) > 0:
             self._add_recent(self.model.current["fname"])


### PR DESCRIPTION
Fix bug that prevented exporting to any file format. Also disable all exporters that don't support epochs for epochs data (currently, only .FIF and .FIF.GZ support epoched data, but I think EEGLAB .SET and BrainVision .EEG should also support that - that's for another PR).