### PR TITLE
Hide statusbar changed in Matplotlib 3.3

### DIFF
--- a/mnelab/dialogs/montagedialog.py
+++ b/mnelab/dialogs/montagedialog.py
@@ -55,6 +55,5 @@ class MontageDialog(QDialog):
         win = fig.canvas.manager.window
         win.setWindowModality(Qt.WindowModal)
         win.setWindowTitle("Montage")
-        win.findChild(QStatusBar).hide()
         win.findChild(QToolBar).hide()
         fig.show()

--- a/mnelab/dialogs/montagedialog.py
+++ b/mnelab/dialogs/montagedialog.py
@@ -3,8 +3,7 @@
 # License: BSD (3-clause)
 
 from qtpy.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QListWidget,
-                            QDialogButtonBox, QPushButton, QStatusBar,
-                            QToolBar)
+                            QDialogButtonBox, QPushButton)
 from qtpy.QtCore import Slot, Qt
 
 from mne.channels import make_standard_montage
@@ -55,5 +54,5 @@ class MontageDialog(QDialog):
         win = fig.canvas.manager.window
         win.setWindowModality(Qt.WindowModal)
         win.setWindowTitle("Montage")
-        win.findChild(QToolBar).hide()
+        win.statusBar().hide()  # not necessary since matplotlib 3.3
         fig.show()

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -600,6 +600,7 @@ class MainWindow(QMainWindow):
         self.model.history.append(hist)
         win = fig.canvas.manager.window
         win.setWindowTitle(self.model.current["name"])
+        win.statusBar().hide()  # not necessary since matplotlib 3.3
         win.installEventFilter(self)  # detect if the figure is closed
 
         # prevent closing the window with the escape key
@@ -632,7 +633,7 @@ class MainWindow(QMainWindow):
                                                       show=False)
         win = fig.canvas.manager.window
         win.setWindowTitle("Montage")
-        win.findChild(QToolBar).hide()
+        win.statusBar().hide()  # not necessary since matplotlib 3.3
         fig.show()
 
     def plot_ica_components(self):

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -600,7 +600,6 @@ class MainWindow(QMainWindow):
         self.model.history.append(hist)
         win = fig.canvas.manager.window
         win.setWindowTitle(self.model.current["name"])
-        win.findChild(QStatusBar).hide()
         win.installEventFilter(self)  # detect if the figure is closed
 
         # prevent closing the window with the escape key
@@ -633,7 +632,6 @@ class MainWindow(QMainWindow):
                                                       show=False)
         win = fig.canvas.manager.window
         win.setWindowTitle("Montage")
-        win.findChild(QStatusBar).hide()
         win.findChild(QToolBar).hide()
         fig.show()
 


### PR DESCRIPTION
Remove status bar from signal plotting and montage plotting. Fixes #161.