### PR TITLE
Show correct signal length (in s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased] - XXXX-XX-XX
+### Fixed
+- Show correct signal length in seconds ([#168](https://github.com/cbrnr/mnelab/pull/168) by [Clemens Brunner](https://github.com/cbrnr))
+
 ### Added
 - Add option to convert events to annotations ([#166](https://github.com/cbrnr/mnelab/pull/166) by [Alberto Barradas](https://github.com/abcsds))
 

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -266,7 +266,7 @@ class Model:
         locations = has_locations(self.current["data"].info)
         ica = self.current["ica"]
 
-        length = f"{len(data.times) / data.info['sfreq']:.6g} s"
+        length = f"{data.times[-1] - data.times[0]:.6g} s"
         samples = f"{len(data.times)}"
         if self.current["dtype"] == "epochs":  # add epoch count
             length = f"{self.current['data'].events.shape[0]} x {length}"


### PR DESCRIPTION
Previously, MNELAB showed an incorrect length in seconds (off by 1 sample). This PR fixes this issue.