### PR TITLE
Event mappings Fix for #167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add option to convert events to annotations ([#166](https://github.com/cbrnr/mnelab/pull/166) by [Alberto Barradas](https://github.com/abcsds))
+- Retain annotation descriptions when converting to events ([#170](https://github.com/cbrnr/mnelab/pull/170) by [Alberto Barradas](https://github.com/abcsds) and [Clemens Brunner](https://github.com/cbrnr))
 
 
 ## [0.5.7] - 2020-07-13

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -131,8 +131,7 @@ class Model:
     @data_changed
     def events_from_annotations(self):
         """Convert annotations to events."""
-        events, event_mappings = mne.events_from_annotations(
-                                    self.current["data"])
+        events, event_mappings = mne.events_from_annotations(self.current["data"])
         # Mappings for annots are swapped {str: int} should be {int: str}
         event_mappings = dict((v, k) for k, v in event_mappings.items())
         if events.shape[0] > 0:
@@ -140,7 +139,8 @@ class Model:
             self.current["event_mappings"] = event_mappings
             self.history.append("events, event_mappings = "
                                 "mne.events_from_annotations(data)"
-                                "event_mappings = dict((v, k) for k, v in event_mappings.items())")
+                                "event_mappings = "
+                                "dict((v, k) for k, v in event_mappings.items())")
 
     @data_changed
     def annotations_from_events(self):
@@ -155,11 +155,10 @@ class Model:
         if len(annots) > 0:
             self.current["data"].set_annotations(annots)
             hist = ('annots = mne.annotations_from_events(data,'
-                    'data.info["sfreq"],')
+                    'data.info["sfreq"]')
             if "event_mappings" in self.current:
-                hist += "event_mappings)"
-            else:
-                hist += ')'
+                hist += ", event_mappings"
+            hist += ')'
             self.history.append(hist)
             self.history.append("data = data.set_annotations(annots)")
 

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -138,32 +138,29 @@ class Model:
             self.current["events"] = events
             self.current["event_mappings"] = mappings
             self.history.append("events, event_mappings = "
-                                "mne.events_from_annotations(data)")
+                                "mne.events_from_annotations(data)"
+                                "mappings = dict((v, k) for k, v in mappings.items())")
 
     @data_changed
     def annotations_from_events(self):
         """Convert events to annotations."""
         if "event_mappings" in self.current:
-            annots = mne.annotations_from_events(
-                self.current["events"],
-                self.current["data"].info["sfreq"],
-                event_desc=self.current["event_mappings"]
-            )
+            mappings = self.current["event_mappings"]
         else:
-            annots = mne.annotations_from_events(
-                self.current["events"],
-                self.current["data"].info["sfreq"],
-            )
+            mappings = None
+        annots = mne.annotations_from_events(self.current["events"],
+                                             self.current["data"].info["sfreq"],
+                                             event_desc=mappings
+                                             )
         if len(annots) > 0:
             self.current["data"].set_annotations(annots)
+            hist = ('annots = mne.annotations_from_events(data,'
+                    'data.info["sfreq"],')
             if "event_mappings" in self.current:
-                self.history.append(
-                    "annots = mne.annotations_from_events(data, "
-                    'data.info["sfreq"], event_mappings)')
+                hist += "event_mappings)"
             else:
-                self.history.append(
-                    "annots = mne.annotations_from_events(data, "
-                    'data.info["sfreq"])')
+                hist += ')'
+            self.history.append(hist)
             self.history.append("data = data.set_annotations(annots)")
 
     def export_data(self, fname, ffilter):

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -132,6 +132,8 @@ class Model:
     def events_from_annotations(self):
         """Convert annotations to events."""
         events, mappings = mne.events_from_annotations(self.current["data"])
+        # Mappings for annots are swapped {str: int} should be {int: str}
+        mappings = dict((v, k) for k, v in mappings.items())
         if events.shape[0] > 0:
             self.current["events"] = events
             self.current["event_mappings"] = mappings
@@ -154,15 +156,15 @@ class Model:
             )
         if len(annots) > 0:
             self.current["data"].set_annotations(annots)
-            self.history.append("""
-if event_mappings is None:
-    annots = mne.annotations_from_events(data, data.info["sfreq"])
-else:
-    annots = mne.annotations_from_events(data,
-                                         data.info["sfreq"],
-                                         event_mappings)
-data = data.set_annotations(annots)
-""")
+            if "event_mappings" in self.current:
+                self.history.append(
+                    "annots = mne.annotations_from_events(data, "
+                    'data.info["sfreq"], event_mappings)')
+            else:
+                self.history.append(
+                    "annots = mne.annotations_from_events(data, "
+                    'data.info["sfreq"])')
+            self.history.append("data = data.set_annotations(annots)")
 
     def export_data(self, fname, ffilter):
         """Export raw to file."""

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -131,27 +131,27 @@ class Model:
     @data_changed
     def events_from_annotations(self):
         """Convert annotations to events."""
-        events, mappings = mne.events_from_annotations(self.current["data"])
+        events, event_mappings = mne.events_from_annotations(
+                                    self.current["data"])
         # Mappings for annots are swapped {str: int} should be {int: str}
-        mappings = dict((v, k) for k, v in mappings.items())
+        event_mappings = dict((v, k) for k, v in event_mappings.items())
         if events.shape[0] > 0:
             self.current["events"] = events
-            self.current["event_mappings"] = mappings
+            self.current["event_mappings"] = event_mappings
             self.history.append("events, event_mappings = "
                                 "mne.events_from_annotations(data)"
-                                "mappings = dict((v, k) for k, v in mappings.items())")
+                                "event_mappings = dict((v, k) for k, v in event_mappings.items())")
 
     @data_changed
     def annotations_from_events(self):
         """Convert events to annotations."""
         if "event_mappings" in self.current:
-            mappings = self.current["event_mappings"]
+            event_mappings = self.current.get("event_mappings")
         else:
-            mappings = None
+            event_mappings = None
         annots = mne.annotations_from_events(self.current["events"],
                                              self.current["data"].info["sfreq"],
-                                             event_desc=mappings
-                                             )
+                                             event_desc=event_mappings)
         if len(annots) > 0:
             self.current["data"].set_annotations(annots)
             hist = ('annots = mne.annotations_from_events(data,'


### PR DESCRIPTION
Store event mappings when calling `mne.events_from_annotations` to be able to use them latter on. This commit also considers that event_mappings should be a dictionary of `event_id` and event descriptions with `event_id` as an integer key of a dictionary, and the event description a string. contrary to how they are returned by the `mne.events_from_annotations` function. A fix for this has been implemented by swapping keys and values.

The `event_mappings` is originally swapped because it can be used when [creating epochs](https://mne.tools/stable/generated/mne.Epochs.html#mne.Epochs). If we plan to use the event mappings here I can remove the swap, and implement it only when converting back to annotations. Currently we only use the `mne.Epochs` in a [single function](https://github.com/cbrnr/mnelab/blob/cce5d7c9fc8cf15bca7f9c600d63647048265ca4/mnelab/model.py#L446) which only uses a list of integer events as far as I know. From the documentation I understand that this list can also be the event_mappings dictionary, instead of the list of events. Did I get it right? Can we use the `event_mappings` for epoching?