### PR TITLE
Simplify requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add option to convert events to annotations ([#166](https://github.com/cbrnr/mnelab/pull/166) by [Alberto Barradas](https://github.com/abcsds))
 - Retain annotation descriptions when converting to events ([#170](https://github.com/cbrnr/mnelab/pull/170) by [Alberto Barradas](https://github.com/abcsds) and [Clemens Brunner](https://github.com/cbrnr))
 
+### Changed
+- Required dependencies are now listed only in one place (requirements.txt) ([#172](https://github.com/cbrnr/mnelab/pull/172) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.5.7] - 2020-07-13
 ### Fixed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools wheel
       python -m pip install PySide2
-      python -m pip install -r requirements-oldest.txt
+      awk '{gsub(/>=/, "==")}1' requirements.txt | xargs python -m pip install
       python -m pip install pytest pytest-azurepipelines pytest-faulthandler pytest-qt pytest-xvfb
     displayName: 'Install dependencies'
   - script: python setup.py develop
@@ -95,7 +95,7 @@ jobs:
       python -m pip install --upgrade pip setuptools wheel
       python -m pip install PySide2
       python -m pip install -r requirements.txt
-      python -m pip install -r requirements-optional.txt
+      python -m pip install -r requirements-extras.txt
       python -m pip install pytest pytest-azurepipelines pytest-faulthandler pytest-qt pytest-xvfb
     displayName: 'Install dependencies'
   - script: python setup.py develop

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,8 @@ jobs:
     displayName: 'Use Python 3.6'
   - script: |
       python -m pip install --upgrade pip setuptools wheel
-      python -m pip install PySide2
-      awk '{gsub(/>=/, "==")}1' requirements.txt | xargs python -m pip install
+      python -m pip install PyQt5==5.10.0
+      awk '{gsub(/>=/, "==")}1' requirements.txt | awk '$0="\x27"$0"\x27"' | xargs python -m pip install
       python -m pip install pytest pytest-azurepipelines pytest-faulthandler pytest-qt pytest-xvfb
     displayName: 'Install dependencies'
   - script: python setup.py develop

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,0 +1,5 @@
+scikit-learn  # fastica
+python-picard  # picard
+pyEDFlib  # edf
+pyxdf  # xdf
+pybv  # brainvision

--- a/requirements-oldest.txt
+++ b/requirements-oldest.txt
@@ -1,6 +1,0 @@
-QtPy==1.9.0
-numpy==1.14.0
-scipy==1.0.0
-matplotlib==2.1.0
-mne==0.20.0
-pyobjc-framework-Cocoa==5.2.0; sys_platform == "darwin"

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,5 +1,0 @@
-scikit-learn
-python-picard
-pyEDFlib
-pyxdf
-pybv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-QtPy
-numpy
-scipy
-matplotlib
-mne
-pyobjc-framework-Cocoa; sys_platform == "darwin"
+mne>=0.20.0
+QtPy>=1.9.0
+numpy>=1.14.0
+scipy>=1.0.0
+matplotlib>=2.1.0
+pyobjc-framework-Cocoa>=5.2.0; platform_system=="Darwin"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,17 @@ with open(path.join('mnelab', 'mainwindow.py'), 'r') as f:
             version = line.split('=')[1].strip().strip('"')
             break
 
+# get install requirements
+with open(path.join(here, "requirements.txt")) as f:
+    requires = f.read().splitlines()
+
+# get extra (optional) requirements
+extras_require = {}
+with open(path.join(here, "requirements-extras.txt")) as f:
+    for extra in f:
+        package, text = extra.split("#")
+        extras_require[text.strip()] = [package.strip()]
+
 setup(
     name='mnelab',
     version=version,
@@ -41,17 +52,8 @@ setup(
     keywords='EEG MEG MNE GUI electrophysiology',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     python_requires='>=3.6, <4',
-    install_requires=['mne>=0.20',
-                      'numpy>=1.14',
-                      'scipy>=1.0',
-                      'matplotlib>=2.1',
-                      'QtPy>=1.9.0',
-                      'pyobjc-framework-Cocoa>=5.2;platform_system=="Darwin"'],
-    extras_require={"EDF export": ["pyedflib"],
-                    "PICARD": ["python-picard"],
-                    "FastICA": ["scikit-learn"],
-                    "XDF import": ["pyxdf"],
-                    "BrainVision export": ["pybv"]},
+    install_requires=requires,
+    extras_require=extras_require,
     license="BSD-3-Clause",
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
This PR attempts to simplify package and version requirements. Previously, we had to change versions in two places (`setup.py`, `requirements-oldest.txt`), whereas now there is only one file (`requirements.txt`). The same is true for optional requirements, which are now only contained in `requirements-extras.txt` (and not in `setup.py` anymore).