### PR TITLE
Include requirements*.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include LICENSE
+include requirements.txt
+include requirements-extras.txt
 recursive-include mnelab/images *
 recursive-include mnelab/icons *


### PR DESCRIPTION
Couldn't install from the sdist otherwise! Maybe consider doing an emergency 0.6.1 release?