### PR TITLE
Fix export ffilter and extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [Unreleased] - XXXX-XX-XX
+### Fixed
+- Fix export functionality ([#184](https://github.com/cbrnr/mnelab/pull/184) by [Guillaume Dollé](https://github.com/gdolle))
+
 ### Changed
 - PySide2 installed by default if wrapped Qt bindings (PyQt5, PySide2) are not found ([#187](https://github.com/cbrnr/mnelab/pull/187) by [Guillaume Dollé](https://github.com/gdolle))
-- Fix export functionality ([#184](https://github.com/cbrnr/mnelab/pull/184) by [Guillaume Dollé](https://github.com/gdolle))
 
 ## [0.6.2] - 2020-10-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased] - XXXX-XX-XX
 ### Changed
 - PySide2 installed by default if wrapped Qt bindings (PyQt5, PySide2) are not found ([#187](https://github.com/cbrnr/mnelab/pull/187) by [Guillaume Dollé](https://github.com/gdolle))
+- Fix export functionality ([#184](https://github.com/cbrnr/mnelab/pull/184) by [Guillaume Dollé](https://github.com/gdolle))
 
 ## [0.6.2] - 2020-10-30
 ### Fixed

--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -64,9 +64,9 @@ def read_raw(fname, *args, **kwargs):
     This function supports reading different file formats. It uses the readers
     dict to dispatch the appropriate read function for a supported file type.
     """
-    maxsuffixes = max([i.count('.') for i in supported ])
+    maxsuffixes = max([i.count('.') for i in supported])
     suffixes = Path(fname).suffixes
-    for i in range(-maxsuffixes,0):
+    for i in range(-maxsuffixes, 0):
         ext = "".join(suffixes[i:])
         if(ext in readers.keys()):
             return readers[ext](fname, *args, **kwargs)

--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -64,10 +64,13 @@ def read_raw(fname, *args, **kwargs):
     This function supports reading different file formats. It uses the readers
     dict to dispatch the appropriate read function for a supported file type.
     """
-    ext = "".join(Path(fname).suffixes)
-    if ext in readers:
-        return readers[ext](fname, *args, **kwargs)
+    maxsuffixes = max([i.count('.') for i in supported ])
+    suffixes = Path(fname).suffixes
+    for i in range(-maxsuffixes,0):
+        ext = "".join(suffixes[i:])
+        if(ext in readers.keys()):
+            return readers[ext](fname, *args, **kwargs)
     else:
-        raise ValueError(f"Unknown file type {ext}.")
+        raise ValueError(f"Unknown file type {suffixes}.")
         # here we could inspect the file signature to determine its type, which
         # would allow us to read file independently of their extensions

--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -64,13 +64,12 @@ def read_raw(fname, *args, **kwargs):
     This function supports reading different file formats. It uses the readers
     dict to dispatch the appropriate read function for a supported file type.
     """
-    maxsuffixes = max([i.count('.') for i in supported])
+    maxsuffixes = max([ext.count(".") for ext in supported])
     suffixes = Path(fname).suffixes
     for i in range(-maxsuffixes, 0):
         ext = "".join(suffixes[i:])
-        if(ext in readers.keys()):
+        if ext in readers.keys():
             return readers[ext](fname, *args, **kwargs)
-    else:
-        raise ValueError(f"Unknown file type {suffixes}.")
-        # here we could inspect the file signature to determine its type, which
-        # would allow us to read file independently of their extensions
+    raise ValueError(f"Unknown file type {suffixes}.")
+    # here we could inspect the file signature to determine its type, which
+    # would allow us to read file independently of their extensions

--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -13,7 +13,7 @@ from ..utils import have
 
 
 def write_fif(fname, raw):
-    raw.save(fname)
+    raw.save(fname,overwrite=True)
 
 
 def write_set(fname, raw):
@@ -47,7 +47,8 @@ def write_edf(fname, raw):
     """Export raw to EDF/BDF file (requires pyEDFlib)."""
     import pyedflib
 
-    ext = "".join(Path(fname).suffixes)
+    suffixes = Path(fname).suffixes
+    ext = "".join(suffixes[-1:])
     if ext == ".edf":
         filetype = pyedflib.FILETYPE_EDFPLUS
         dmin, dmax = -32768, 32767
@@ -124,8 +125,11 @@ if have["pyedflib"]:
 
 
 def write_raw(fname, raw):
-    ext = "".join(Path(fname).suffixes)
-    if ext in writers:
-        writers[ext][0](fname, raw)
+    maxsuffixes = max([i.count('.') for i in writers.keys() ])
+    suffixes = Path(fname).suffixes
+    for i in range(-maxsuffixes,0):
+        ext = "".join(suffixes[i:])
+        if(ext in writers.keys()):
+            return writers[ext][0](fname, raw)
     else:
-        raise ValueError(f"Unknown file type {ext}.")
+        raise ValueError(f"Unknown file type '{suffixes}'.")

--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -13,7 +13,7 @@ from ..utils import have
 
 
 def write_fif(fname, raw):
-    raw.save(fname,overwrite=True)
+    raw.save(fname, overwrite=True)
 
 
 def write_set(fname, raw):
@@ -125,9 +125,9 @@ if have["pyedflib"]:
 
 
 def write_raw(fname, raw):
-    maxsuffixes = max([i.count('.') for i in writers.keys() ])
+    maxsuffixes = max([i.count('.') for i in writers.keys()])
     suffixes = Path(fname).suffixes
-    for i in range(-maxsuffixes,0):
+    for i in range(-maxsuffixes, 0):
         ext = "".join(suffixes[i:])
         if(ext in writers.keys()):
             return writers[ext][0](fname, raw)

--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -125,11 +125,11 @@ if have["pyedflib"]:
 
 
 def write_raw(fname, raw):
-    maxsuffixes = max([i.count('.') for i in writers.keys()])
+    maxsuffixes = max([ext.count(".") for ext in writers.keys()])
     suffixes = Path(fname).suffixes
     for i in range(-maxsuffixes, 0):
         ext = "".join(suffixes[i:])
-        if(ext in writers.keys()):
+        if ext in writers.keys():
             return writers[ext][0](fname, raw)
     else:
         raise ValueError(f"Unknown file type '{suffixes}'.")

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -133,7 +133,7 @@ class MainWindow(QMainWindow):
             self.actions[action] = self.export_menu.addAction(
                 f"{ext[1:].upper()} ({description[1]})...",
                 partial(self.export_file, model.export_data, "Export data",
-                        self.tr("*"+ext)))
+                        "*" + ext))
         self.actions["export_bads"] = file_menu.addAction(
             "Export &bad channels...",
             lambda: self.export_file(model.export_bads, "Export bad channels",
@@ -444,20 +444,17 @@ class MainWindow(QMainWindow):
     def export_file(self, f, text, ffilter="*"):
         """Export to file."""
         fname = QFileDialog.getSaveFileName(self, text, filter=ffilter)[0]
-        if(fname):
-            if(ffilter != "*"):
-                fflist = re.split(" +", ffilter)
-                exts = [i.replace('*', '') for i in fflist]
+        if fname:
+            if ffilter != "*":
+                exts = [ext.replace("*", "") for ext in ffilter.split()]
 
-                maxsuffixes = max([i.count('.') for i in exts])
+                maxsuffixes = max([ext.count(".") for ext in exts])
                 suffixes = Path(fname).suffixes
                 for i in range(-maxsuffixes, 0):
                     ext = "".join(suffixes[i:])
-                    if(ext in exts):
-                        print("Export file: ", fname)
+                    if ext in exts:
                         return f(fname)
                 fname = fname + exts[0]
-                print("Export to file: ", fname)
                 return f(fname)
 
     def import_file(self, f, text, ffilter="*"):

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -445,13 +445,13 @@ class MainWindow(QMainWindow):
         """Export to file."""
         fname = QFileDialog.getSaveFileName(self, text, filter=ffilter)[0]
         if(fname):
-            if(ffilter!="*"):
-                fflist = re.split(" +",ffilter)
-                exts = [i.replace('*','') for i in fflist]
+            if(ffilter != "*"):
+                fflist = re.split(" +", ffilter)
+                exts = [i.replace('*', '') for i in fflist]
 
                 maxsuffixes = max([i.count('.') for i in exts])
                 suffixes = Path(fname).suffixes
-                for i in range(-maxsuffixes,0):
+                for i in range(-maxsuffixes, 0):
                     ext = "".join(suffixes[i:])
                     if(ext in exts):
                         print("Export file: ", fname)

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -7,7 +7,6 @@ from sys import version_info
 import traceback
 from functools import partial
 from pathlib import Path
-import re
 
 import numpy as np
 import mne

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -7,6 +7,7 @@ from sys import version_info
 import traceback
 from functools import partial
 from pathlib import Path
+import re
 
 import numpy as np
 import mne
@@ -132,7 +133,7 @@ class MainWindow(QMainWindow):
             self.actions[action] = self.export_menu.addAction(
                 f"{ext[1:].upper()} ({description[1]})...",
                 partial(self.export_file, model.export_data, "Export data",
-                        ext))
+                        self.tr("*"+ext)))
         self.actions["export_bads"] = file_menu.addAction(
             "Export &bad channels...",
             lambda: self.export_file(model.export_bads, "Export bad channels",
@@ -443,11 +444,21 @@ class MainWindow(QMainWindow):
     def export_file(self, f, text, ffilter="*"):
         """Export to file."""
         fname = QFileDialog.getSaveFileName(self, text, filter=ffilter)[0]
-        if fname:
-            try:
-                f(fname, ffilter)
-            except TypeError:
-                f(fname)
+        if(fname):
+            if(ffilter!="*"):
+                fflist = re.split(" +",ffilter)
+                exts = [i.replace('*','') for i in fflist]
+
+                maxsuffixes = max([i.count('.') for i in exts])
+                suffixes = Path(fname).suffixes
+                for i in range(-maxsuffixes,0):
+                    ext = "".join(suffixes[i:])
+                    if(ext in exts):
+                        print("Export file: ", fname)
+                        return f(fname)
+                fname = fname + exts[0]
+                print("Export to file: ", fname)
+                return f(fname)
 
     def import_file(self, f, text, ffilter="*"):
         """Import file."""

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -159,12 +159,8 @@ class Model:
             self.history.append(hist)
             self.history.append("data = data.set_annotations(annots)")
 
-    def export_data(self, fname, ffilter):
+    def export_data(self, fname):
         """Export raw to file."""
-        ext = "".join(Path(fname).suffixes)
-        if ext != ffilter:
-            ext = ffilter
-            fname += ext
         write_raw(fname, self.current["data"])
 
     def export_bads(self, fname):


### PR DESCRIPTION
This PR fix issues #183 #176

- Concerning #176, ffilter argument removed
- Fix ffilter. Files should now be listed in import/export dialog
- Fix writers/readers extension check to allow dot in file names #183 
- Fix an export .fif crash when the named file exist (managed via QDialogFile)

NB: This just fix export issues but isn't an export refactoring for #178