### PR TITLE
Fix optional deps for conda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased] - XXXX-XX-XX
+### Fixed
+- Fix package installation in conda environments (properly detect if `PyQt5` is installed) ([#194](https://github.com/cbrnr/mnelab/pull/194) by [Clemens Brunner](https://github.com/cbrnr))
+
 ### Changed
 - Rename `master` branch to `main` ([#193](https://github.com/cbrnr/mnelab/pull/193) by [Clemens Brunner](https://github.com/cbrnr))
 

--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,29 @@ from os import path
 from importlib import import_module
 
 
-def optdep(*args, default=None):
-    """Manage alternative dependencies."""
+def optdep(*args):
+    """Manage optional dependencies.
+
+    Parameters
+    ----------
+    *args : str
+        Module names to check if they are installed.
+
+    Returns
+    -------
+    pkg : str | None
+        Package name that should be added to requires so that it will be
+        installed automatically. If any package in *args is installed, this
+        will return None. Otherwise, if no package is installed this will
+        return the first package in *args.
+    """
     for dep in args:
         try:
             import_module(dep)
         except ImportError:
             continue
-        else:
-            return dep
-    return default
+        return
+    return args[0]
 
 
 here = path.abspath(path.dirname(__file__))
@@ -36,8 +49,10 @@ with open(path.join('mnelab', 'mainwindow.py'), 'r') as f:
 with open(path.join(here, "requirements.txt")) as f:
     requires = f.read().splitlines()
 
-qtpkg = optdep("PySide2", "PyQt5", default="PySide2")
-requires.append(qtpkg)
+# check if either PySide2 or PyQt5 is installed; if not add PySide2 to requires
+qtpkg = optdep("PySide2", "PyQt5")
+if qtpkg is not None:
+    requires.append(qtpkg)
 
 # get extra (optional) requirements
 extras_require = {}


### PR DESCRIPTION
Previously, checking if `PySide2` or `PyQt5` was installed in conda environments didn't work as expected, because the conda package name `pyqt` is not identical to the module name `PyQt5`. That's why even if `pyqt` was installed, `setup.py` still installed `PyQt5` (from PyPI).