### PR TITLE
Remove custom setup.py dep check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased] - XXXX-XX-XX
 ### Fixed
-- Fix package installation in conda environments (properly detect if `PyQt5` is installed) ([#194](https://github.com/cbrnr/mnelab/pull/194) by [Clemens Brunner](https://github.com/cbrnr))
+- Remove auto-installation of `PySide2` when using `pip` ([#196](https://github.com/cbrnr/mnelab/pull/196) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Changed
 - Rename `master` branch to `main` ([#193](https://github.com/cbrnr/mnelab/pull/193) by [Clemens Brunner](https://github.com/cbrnr))

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Make sure you have either `PySide2` or `PyQt5` installed. If you have neither, w
 pip install mnelab
 ```
 
+If you want to install either `PySide2` or `PyQt5` alongside MNELAB with one go, you can also use either `pip install mnelab[pyside2]` or `pip install mnelab[pyqt5]`.
+
 You can start MNELAB in a terminal with `mnelab` or `python -m mnelab`.
 
 #### conda

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ MNELAB requires Python >= 3.6 and the following packages:
 - [python.app](https://anaconda.org/anaconda/python.app) (only when using Anaconda on macOS)
 
 Optional dependencies provide additional features if installed:
-- [scikit-learn]() (ICA computation with FastICA)
-- [python-picard](https://pierreablin.github.io/picard/) (ICA computation with PICARD)
-- [pyxdf](https://github.com/xdf-modules/xdf-Python) (XDF import)
-- [pyEDFlib](https://github.com/holgern/pyedflib) (EDF/BDF export)
-- [pybv](https://github.com/bids-standard/pybv) (BrainVision VHDR/VMRK/EEG export)
+- [scikit-learn](https://scikit-learn.org/stable/) >= 0.20.0 (ICA computation with FastICA)
+- [python-picard](https://pierreablin.github.io/picard/) >= 0.4.0 (ICA computation with PICARD)
+- [pyxdf](https://github.com/xdf-modules/xdf-Python) >= 1.16.0 (XDF import)
+- [pyEDFlib](https://github.com/holgern/pyedflib) >= 0.1.15 (EDF/BDF export)
+- [pybv](https://github.com/bids-standard/pybv) 0.4.0 (BrainVision VHDR/VMRK/EEG export)
 
 ### Additional features
 MNELAB comes with the following features that are not (yet) available in MNE:

--- a/README.md
+++ b/README.md
@@ -12,25 +12,25 @@ MNELAB is a graphical user interface (GUI) for [MNE](https://github.com/mne-tool
 ![](https://raw.githubusercontent.com/cbrnr/mnelab/main/mnelab.png)
 
 ### Changelog
-Check out the [changelog](https://github.com/cbrnr/mnelab/blob/main/CHANGELOG.md) to learn what we added, changed or fixed in the latest version.
+Check out the [changelog](https://github.com/cbrnr/mnelab/blob/main/CHANGELOG.md) to learn what we added, changed or fixed in the latest release.
 
 ### Dependencies
 MNELAB requires Python >= 3.6 and the following packages:
+- [mne](https://github.com/mne-tools/mne-python) >= 0.22.0
 - [QtPy](https://github.com/spyder-ide/qtpy) >= 1.9.0
 - [PyQt5](https://www.riverbankcomputing.com/software/pyqt/download5) >= 5.10.0 or [PySide2](https://www.qt.io/qt-for-python) >= 5.10.0
 - [numpy](http://www.numpy.org/) >= 1.14.0
 - [scipy](https://www.scipy.org/scipylib/index.html) >= 1.0.0
 - [matplotlib](https://matplotlib.org/) >= 2.1.0
-- [mne](https://github.com/mne-tools/mne-python) >= 0.22.0
 - [pyobjc-framework-Cocoa](https://pyobjc.readthedocs.io/en/latest/) >= 5.2.0 (macOS only)
 - [python.app](https://anaconda.org/anaconda/python.app) (only when using Anaconda on macOS)
 
 Optional dependencies provide additional features if installed:
 - [scikit-learn]() (ICA computation with FastICA)
 - [python-picard](https://pierreablin.github.io/picard/) (ICA computation with PICARD)
-- [pyxdf](https://github.com/xdf-modules/xdf-Python) (import XDF)
-- [pyEDFlib](https://github.com/holgern/pyedflib) (export to EDF/BDF)
-- [pybv](https://github.com/bids-standard/pybv) (export to BrainVision VHDR/VMRK/EEG)
+- [pyxdf](https://github.com/xdf-modules/xdf-Python) (XDF import)
+- [pyEDFlib](https://github.com/holgern/pyedflib) (EDF/BDF export)
+- [pybv](https://github.com/bids-standard/pybv) (BrainVision VHDR/VMRK/EEG export)
 
 ### Additional features
 MNELAB comes with the following features that are not (yet) available in MNE:
@@ -41,7 +41,7 @@ MNELAB comes with the following features that are not (yet) available in MNE:
 
 ### Installation
 #### pip
-MNELAB requires either PyQt5 or PySide2 (if you don't have either of these packages installed, MNELAB will automatically install and use PySide2):
+Make sure you have either `PySide2` or `PyQt5` installed. If you have neither, we recommend `PySide2`, which you can install with `pip install PySide2`. Then install MNELAB with:
 
 ```
 pip install mnelab
@@ -61,13 +61,6 @@ You can start MNELAB in a terminal with `conda activate mnelab` followed by `mne
 
 #### Arch Linux
 If you use [Arch Linux](https://www.archlinux.org/), you can install the [python-mnelab](https://aur.archlinux.org/packages/python-mnelab/) AUR package (note that this also requires the [python-mne](https://aur.archlinux.org/packages/python-mne/) AUR package).
-
-#### Development version
-Follow these steps to use the latest development version of MNELAB:
-
-1. [Download the source code](https://github.com/cbrnr/mnelab/archive/main.zip) and unpack it into a folder of your choice.
-2. Install all dependencies listed above.
-3. Run `python -m mnelab` to start MNELAB (if this does not work try `python3 -m mnelab` because Python 2 is not supported).
 
 ### Contributing
 The [contributing guide](https://github.com/cbrnr/mnelab/blob/main/CONTRIBUTING.md) contains detailed instructions on how to contribute to MNELAB.

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,5 +1,7 @@
-scikit-learn  # fastica
-python-picard  # picard
-pyEDFlib  # edf
-pyxdf  # xdf
-pybv  # brainvision
+scikit-learn>=0.20.0  # fastica
+python-picard>=0.4.0  # picard
+pyEDFlib>=0.1.15  # edf
+pyxdf>=1.16.0  # xdf
+pybv>=0.4.0  # brainvision
+PyQt5>=5.10.0  # pyqt5
+PySide2>=5.10.0  # pyside2

--- a/setup.py
+++ b/setup.py
@@ -4,32 +4,6 @@
 
 from setuptools import setup, find_packages
 from os import path
-from importlib import import_module
-
-
-def optdep(*args):
-    """Manage optional dependencies.
-
-    Parameters
-    ----------
-    *args : str
-        Module names to check if they are installed.
-
-    Returns
-    -------
-    pkg : str | None
-        Package name that should be added to requires so that it will be
-        installed automatically. If any package in *args is installed, this
-        will return None. Otherwise, if no package is installed this will
-        return the first package in *args.
-    """
-    for dep in args:
-        try:
-            import_module(dep)
-        except ImportError:
-            continue
-        return
-    return args[0]
 
 
 here = path.abspath(path.dirname(__file__))
@@ -48,11 +22,6 @@ with open(path.join('mnelab', 'mainwindow.py'), 'r') as f:
 # get install requirements
 with open(path.join(here, "requirements.txt")) as f:
     requires = f.read().splitlines()
-
-# check if either PySide2 or PyQt5 is installed; if not add PySide2 to requires
-qtpkg = optdep("PySide2", "PyQt5")
-if qtpkg is not None:
-    requires.append(qtpkg)
 
 # get extra (optional) requirements
 extras_require = {}


### PR DESCRIPTION
Checking for `PyQt5` or `PySide2` and installing the latter of none is found is rather ad-hoc and doesn't work in many situations. Therefore, I'm removing this feature again and instead will rely on best practices, i.e. users are responsible to install either of these two packages themselves. In addition, `pip install mnelab[pyside2]` and `pip install mnelab[pyqt5]` is now also supported.