### PR TITLE
Workaround for mnelab command not working on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased] - XXXX-XX-XX
 ### Fixed
 - Remove auto-installation of `PySide2` when using `pip` ([#196](https://github.com/cbrnr/mnelab/pull/196) by [Clemens Brunner](https://github.com/cbrnr))
+- Starting MNELAB with the `mnelab` command in a terminal now also works on Windows ([#197](https://github.com/cbrnr/mnelab/pull/197) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Changed
 - Rename `master` branch to `main` ([#193](https://github.com/cbrnr/mnelab/pull/193) by [Clemens Brunner](https://github.com/cbrnr))

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     license="BSD-3-Clause",
     include_package_data=True,
     entry_points={
-        'gui_scripts': [
+        'console_scripts': [
             'mnelab=mnelab.__main__:main',
         ],
     }


### PR DESCRIPTION
Fixes #153. Basically, I'm replacing`gui_scripts` with `console_scripts`, which works on all supported platforms. This means that the terminal needs to remain open while MNELAB is running. However, this was already the case on Linux and macOS, so it seems like the `gui_scripts` entry point never worked.