### PR TITLE
Add theme detection for Windows

### DIFF
--- a/mnelab/utils/utils.py
+++ b/mnelab/utils/utils.py
@@ -34,9 +34,14 @@ def interface_style():
             return "light"
     elif sys.platform.startswith("win"):
         from winreg import OpenKey, QueryValueEx, HKEY_CURRENT_USER
-        s = r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+        s = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
         with OpenKey(HKEY_CURRENT_USER, s) as key:
-            value = QueryValueEx(key, "AppsUseLightTheme")[0]
+            from winreg import QueryInfoKey, EnumValue
+            info = QueryInfoKey(key)
+            print(info)
+            for i in range(info[1]):
+                print(EnumValue(key, i))
+            value, _ = QueryValueEx(key, "AppsUseLightTheme")
         if value == 0:
             return "dark"
         else:

--- a/mnelab/utils/utils.py
+++ b/mnelab/utils/utils.py
@@ -2,6 +2,7 @@
 #
 # License: BSD (3-clause)
 
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -20,12 +21,23 @@ def image_path(fname):
 
 def interface_style():
     """Return current platform interface style (light or dark)."""
-    try:  # currently only works on macOS
-        from Foundation import NSUserDefaults as NSUD
-    except ImportError:
-        return None
-    style = NSUD.standardUserDefaults().stringForKey_("AppleInterfaceStyle")
-    if style == "Dark":
-        return "dark"
-    else:
-        return "light"
+    if sys.platform.startswith("darwin"):
+        try:
+            from Foundation import NSUserDefaults
+        except ImportError:
+            return None
+        defaults = NSUserDefaults.standardUserDefaults()
+        style = defaults.stringForKey_("AppleInterfaceStyle")
+        if style == "Dark":
+            return "dark"
+        else:
+            return "light"
+    elif sys.platform.startswith("win"):
+        from winreg import OpenKey, QueryValueEx, HKEY_CURRENT_USER
+        s = r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+        with OpenKey(HKEY_CURRENT_USER, s) as key:
+            value = QueryValueEx(key, "AppsUseLightTheme")[0]
+        if value == 0:
+            return "dark"
+        else:
+            return "light"

--- a/mnelab/utils/utils.py
+++ b/mnelab/utils/utils.py
@@ -36,12 +36,10 @@ def interface_style():
         from winreg import OpenKey, QueryValueEx, HKEY_CURRENT_USER
         s = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
         with OpenKey(HKEY_CURRENT_USER, s) as key:
-            from winreg import QueryInfoKey, EnumValue
-            info = QueryInfoKey(key)
-            print(info)
-            for i in range(info[1]):
-                print(EnumValue(key, i))
-            value, _ = QueryValueEx(key, "AppsUseLightTheme")
+            try:
+                value, _ = QueryValueEx(key, "AppsUseLightTheme")
+            except FileNotFoundError:
+                return None
         if value == 0:
             return "dark"
         else:


### PR DESCRIPTION
Currently light/dark theme detection works only on macOS. On Windows and Linux, Qt apps still don't have native dark theme support 😞.