### PR TITLE
Remove conda-specific code and instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - Rename `master` branch to `main` ([#193](https://github.com/cbrnr/mnelab/pull/193) by [Clemens Brunner](https://github.com/cbrnr))
 - Simplify dependencies ([#199](https://github.com/cbrnr/mnelab/pull/199) by [Clemens Brunner](https://github.com/cbrnr))
+- Remove instructions and workarounds specific to `conda` environments ([#223](https://github.com/cbrnr/mnelab/pull/223) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.6.3] - 2021-01-05
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ MNELAB requires Python >= 3.6 and the following packages:
 - [scipy](https://www.scipy.org/scipylib/index.html) >= 1.0.0
 - [matplotlib](https://matplotlib.org/) >= 2.1.0
 - [pyobjc-framework-Cocoa](https://pyobjc.readthedocs.io/en/latest/) >= 5.2.0 (macOS only)
-- [python.app](https://anaconda.org/anaconda/python.app) (only when using Anaconda on macOS)
 
 Optional dependencies provide additional features if installed:
 - [scikit-learn](https://scikit-learn.org/stable/) >= 0.20.0 (ICA computation with FastICA)
@@ -31,7 +30,6 @@ Optional dependencies provide additional features if installed:
 - [pybv](https://github.com/bids-standard/pybv) 0.4.0 (BrainVision VHDR/VMRK/EEG export)
 
 ### Installation
-#### pip
 Make sure you have either `PySide2` or `PyQt5` installed. If you have neither, we recommend `PySide2`, which you can install with `pip install PySide2`. Then install MNELAB with:
 
 ```
@@ -44,22 +42,9 @@ To use all MNELAB features, all optional dependencies should also be installed:
 pip install scikit-learn python-picard pyxdf pyEDFlib pybv
 ```
 
-If you want to install either `PySide2` or `PyQt5` alongside MNELAB with one go, you can also use either `pip install mnelab[pyside2]` or `pip install mnelab[pyqt5]`.
-
 You can start MNELAB in a terminal with `mnelab` or `python -m mnelab`.
 
-#### conda
-An unofficial but regularly updated conda package can be installed from [conda-forge](https://conda-forge.org/).
-We strongly suggest to install MNELAB into its own dedicated environment:
-
-```
-conda create -y -n mnelab -c conda-forge mnelab
-```
-
-You can start MNELAB in a terminal with `conda activate mnelab` followed by `mnelab` or `python -m mnelab`. Any issues with this conda package should be reported to the package [issue tracker](https://github.com/conda-forge/mnelab-feedstock/issues).
-
-#### Arch Linux
-If you use [Arch Linux](https://www.archlinux.org/), you can install the [python-mnelab](https://aur.archlinux.org/packages/python-mnelab/) AUR package (note that this also requires the [python-mne](https://aur.archlinux.org/packages/python-mne/) AUR package).
+If you use [Arch Linux](https://www.archlinux.org/), you can alternatively install the [python-mnelab](https://aur.archlinux.org/packages/python-mnelab/) AUR package (note that this also requires the [python-mne](https://aur.archlinux.org/packages/python-mne/) AUR package).
 
 ### Contributing
 The [contributing guide](https://github.com/cbrnr/mnelab/blob/main/CONTRIBUTING.md) contains detailed instructions on how to contribute to MNELAB.

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -3,7 +3,6 @@
 # License: BSD (3-clause)
 
 import sys
-import os
 import multiprocessing as mp
 import matplotlib
 from qtpy.QtWidgets import QApplication
@@ -12,7 +11,8 @@ from qtpy.QtCore import Qt
 from . import MainWindow, Model
 
 
-def _run():
+def main():
+    mp.set_start_method("spawn", force=True)  # required for Linux/macOS
     app_name = "MNELAB"
     if sys.platform.startswith("darwin"):
         try:  # set bundle name on macOS (app name shown in the menu bar)
@@ -42,45 +42,5 @@ def _run():
     sys.exit(app.exec_())
 
 
-def _run_pythonw():
-    """Execute this script again through pythonw.
-
-    This ensures we're using a framework build of Python on macOS.
-    """
-    import pathlib
-    import subprocess
-
-    cwd = pathlib.Path.cwd()
-    python_path = pathlib.Path(sys.exec_prefix) / "bin" / "pythonw"
-
-    if not python_path.exists():
-        raise RuntimeError("pythonw executable not found. "
-                           "Please install python.app via conda.")
-
-    cmd = [python_path, "-m", "mnelab"]
-
-    # Append command line arguments.
-    if len(sys.argv) > 1:
-        cmd.append(*sys.argv[1:])
-
-    env = os.environ.copy()
-    env["MNELAB_RUNNING_PYTHONW"] = "True"
-
-    subprocess.run(cmd, env=env, cwd=cwd)
-    sys.exit()
-
-
-def main():
-    # ensure we're always using a framework build when using conda on macOS
-    _MACOS_CONDA = sys.platform == "darwin" and "CONDA_PREFIX" in os.environ
-    _RUNNING_PYTHONW = "MNELAB_RUNNING_PYTHONW" in os.environ
-
-    if _MACOS_CONDA and not _RUNNING_PYTHONW:
-        _run_pythonw()
-    else:
-        _run()
-
-
 if __name__ == "__main__":
-    mp.set_start_method("spawn", force=True)  # required for Linux/macOS
     main()


### PR DESCRIPTION
Installing with `pip` should also work in `conda` environments. There are still problems with GUI applications using `conda` on macOS, but this should be fixed upstream and not worked around here.