### PR TITLE
Fix gui_scripts entrypoint

### DIFF
--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -2,44 +2,7 @@
 #
 # License: BSD (3-clause)
 
-import sys
-import multiprocessing as mp
-import matplotlib
-from qtpy.QtWidgets import QApplication
-from qtpy.QtCore import Qt
-
-from . import MainWindow, Model
-
-
-def main():
-    mp.set_start_method("spawn", force=True)  # required for Linux/macOS
-    app_name = "MNELAB"
-    if sys.platform.startswith("darwin"):
-        try:  # set bundle name on macOS (app name shown in the menu bar)
-            from Foundation import NSBundle
-        except ImportError:
-            pass
-        else:
-            bundle = NSBundle.mainBundle()
-            if bundle:
-                info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
-                if info:
-                    info["CFBundleName"] = app_name
-
-    matplotlib.use("Qt5Agg")
-    app = QApplication(sys.argv)
-    app.setApplicationName(app_name)
-    app.setOrganizationName("cbrnr")
-    if sys.platform.startswith("darwin"):
-        app.setAttribute(Qt.AA_DontShowIconsInMenus, True)
-    app.setAttribute(Qt.AA_UseHighDpiPixmaps)
-    model = Model()
-    model.view = MainWindow(model)
-    if len(sys.argv) > 1:  # open files from command line arguments
-        for f in sys.argv[1:]:
-            model.load(f)
-    model.view.show()
-    sys.exit(app.exec_())
+from . import main
 
 
 if __name__ == "__main__":

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -17,7 +17,6 @@ from qtpy.QtGui import QKeySequence, QDropEvent, QIcon
 from qtpy.QtWidgets import (QApplication, QMainWindow, QFileDialog, QSplitter, QMessageBox,
                             QListView, QAction, QLabel, QFrame)
 
-from . import __version__
 from .dialogs import (AnnotationsDialog, AppendDialog, CalcDialog, ChannelPropertiesDialog,
                       CropDialog, ERDSDialog, EpochDialog, ErrorMessageBox, EventsDialog,
                       FilterDialog, FindEventsDialog, HistoryDialog, InterpolateBadsDialog,
@@ -808,6 +807,8 @@ class MainWindow(QMainWindow):
 
     def show_about(self):
         """Show About dialog."""
+        from . import __version__
+
         msg_box = QMessageBox(self)
         text = (f"<img src='{image_path('mnelab_logo.png')}'><p>MNELAB {__version__}</p>")
         msg_box.setText(text)

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,8 @@ full =
     PySide2>=5.10.0  # pyside2
 
 [options.entry_points]
-console_scripts =
-    mnelab = mnelab.__main__:main
+gui_scripts =
+    mnelab = mnelab:main
 
 [flake8]
 max-line-length = 92


### PR DESCRIPTION
The `gui_scripts` entry point was broken on Windows. Slightly refactoring the contents of `__init__.py` and `__main__.py` fixes this issue.