### PR TITLE
Fix history for loading XDF and dropping channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED] - XXXX-XX-XX
+### Fixed
+- Fix history for importing XDF files and dropping channels ([#234](https://github.com/cbrnr/mnelab/pull/234) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [0.6.5] - 2021-11-08
 ### Fixed
 - Fix EDF/BDF export of data containing stim channels ([#230](https://github.com/cbrnr/mnelab/pull/230) by [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -471,11 +471,11 @@ class MainWindow(QMainWindow):
         dialog = PickChannelsDialog(self, channels, selected=channels)
         if dialog.exec_():
             picks = [item.data(0) for item in dialog.channels.selectedItems()]
-            drops = set(channels) - set(picks)
+            drops = list(set(channels) - set(picks))
             if drops:
                 self.auto_duplicate()
                 self.model.drop_channels(drops)
-                self.model.history.append(f"raw.drop({drops})")
+                self.model.history.append(f"data.drop_channels({drops})")
 
     def channel_properties(self):
         """Show channel properties dialog."""

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -104,8 +104,13 @@ class Model:
     @data_changed
     def load(self, fname, *args, **kwargs):
         """Load data set from file."""
-        data = read_raw(fname, *args, preload=True, **kwargs)
-        self.history.append(f'data = read_raw("{fname}", preload=True)')
+        data = read_raw(fname, *args, **kwargs, preload=True)
+        argstr = ", " + f"{', '.join(f'{v}' for v in args)}" if args else ""
+        if kwargs:
+            kwargstr = ", " + f"{', '.join(f'{k}={v}' for k, v in kwargs.items())}"
+        else:
+            kwargstr = ""
+        self.history.append(f'data = read_raw("{fname}"{argstr}{kwargstr}, preload=True)')
         fsize = getsize(data.filenames[0]) / 1024**2  # convert to MB
         name, ext = Path(fname).stem, "".join(Path(fname).suffixes)
         self.insert_data(defaultdict(lambda: None, name=name, fname=fname,


### PR DESCRIPTION
Loading XDF requires the `stream_id` argument, and the history for dropping channels was completely wrong.