### PR TITLE
Add option to use effective sampling rate for XDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [UNRELEASED] - XXXX-XX-XX
+### Added
+- Add option to use effective sampling rate when importing XDF files ([#236](https://github.com/cbrnr/mnelab/pull/236) by [Clemens Brunner](https://github.com/cbrnr))
+
 ### Fixed
 - Fix history for importing XDF files and dropping channels ([#234](https://github.com/cbrnr/mnelab/pull/234) by [Clemens Brunner](https://github.com/cbrnr))
 
@@ -26,15 +29,15 @@
 - Remove instructions and workarounds specific to `conda` environments ([#223](https://github.com/cbrnr/mnelab/pull/223) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.6.3] - 2021-01-05
+### Added
+- Add Python 3.9 support ([#190](https://github.com/cbrnr/mnelab/pull/190) by [Clemens Brunner](https://github.com/cbrnr))
+
 ### Fixed
 - Fix export functionality ([#184](https://github.com/cbrnr/mnelab/pull/184) by [Guillaume Dollé](https://github.com/gdolle))
 - Fix ICA computation in separate process ([#192](https://github.com/cbrnr/mnelab/pull/192) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Changed
 - PySide2 installed by default if wrapped Qt bindings (PyQt5, PySide2) are not found ([#187](https://github.com/cbrnr/mnelab/pull/187) by [Guillaume Dollé](https://github.com/gdolle))
-
-### Added
-- Add Python 3.9 support ([#190](https://github.com/cbrnr/mnelab/pull/190) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.6.2] - 2020-10-30
 ### Fixed
@@ -45,16 +48,16 @@
 - Include `requirements.txt` in MANIFEST.in (by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.6.0] - 2020-10-30
-### Fixed
-- Show correct signal length in seconds ([#168](https://github.com/cbrnr/mnelab/pull/168) by [Clemens Brunner](https://github.com/cbrnr))
-- Fix export functionality ([#177](https://github.com/cbrnr/mnelab/pull/177) by [Guillaume Dollé](https://github.com/gdolle) and [Clemens Brunner](https://github.com/cbrnr))
-
 ### Added
 - Add option to convert events to annotations ([#166](https://github.com/cbrnr/mnelab/pull/166) by [Alberto Barradas](https://github.com/abcsds))
 - Retain annotation descriptions when converting to events ([#170](https://github.com/cbrnr/mnelab/pull/170) by [Alberto Barradas](https://github.com/abcsds) and [Clemens Brunner](https://github.com/cbrnr))
 - Add support for basic ERDS maps ([#174](https://github.com/cbrnr/mnelab/pull/174) by [Clemens Brunner](https://github.com/cbrnr))
 - Add syntax highlighting in history dialog ([#179](https://github.com/cbrnr/mnelab/pull/179) by [Clemens Brunner](https://github.com/cbrnr))
 - Add copy to clipboard in history dialog ([#180](https://github.com/cbrnr/mnelab/pull/180) by [Clemens Brunner](https://github.com/cbrnr))
+
+### Fixed
+- Show correct signal length in seconds ([#168](https://github.com/cbrnr/mnelab/pull/168) by [Clemens Brunner](https://github.com/cbrnr))
+- Fix export functionality ([#177](https://github.com/cbrnr/mnelab/pull/177) by [Guillaume Dollé](https://github.com/gdolle) and [Clemens Brunner](https://github.com/cbrnr))
 
 ### Changed
 - Required dependencies are now listed only in one place (requirements.txt) ([#172](https://github.com/cbrnr/mnelab/pull/172) by [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/dialogs/xdfstreamsdialog.py
+++ b/mnelab/dialogs/xdfstreamsdialog.py
@@ -3,7 +3,7 @@
 # License: BSD (3-clause)
 
 from qtpy.QtWidgets import (QDialog, QVBoxLayout, QDialogButtonBox, QAbstractItemView,
-                            QTableView)
+                            QTableView, QCheckBox)
 from qtpy.QtGui import QStandardItemModel, QStandardItem
 from qtpy.QtCore import Qt
 
@@ -43,12 +43,19 @@ class XDFStreamsDialog(QDialog):
 
         vbox = QVBoxLayout(self)
         vbox.addWidget(self.view)
+        self._effective_srate = QCheckBox("Use effective sampling rate")
+        self._effective_srate.setChecked(True)
+        vbox.addWidget(self._effective_srate)
         self.buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         vbox.addWidget(self.buttonbox)
         self.buttonbox.accepted.connect(self.accept)
         self.buttonbox.rejected.connect(self.reject)
 
         self.resize(775, 650)
-        self.view.setColumnWidth(0, 100)
+        self.view.setColumnWidth(0, 80)
         self.view.setColumnWidth(1, 200)
-        self.view.setColumnWidth(2, 120)
+        self.view.setColumnWidth(2, 140)
+
+    @property
+    def effective_srate(self):
+        return self._effective_srate.isChecked()

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -410,7 +410,8 @@ class MainWindow(QMainWindow):
                 if dialog.exec_():
                     row = dialog.view.selectionModel().selectedRows()[0].row()
                     stream_id = dialog.model.data(dialog.model.index(row, 0))
-                    self.model.load(fname, stream_id=stream_id)
+                    srate = "effective" if dialog.effective_srate else "nominal"
+                    self.model.load(fname, stream_id=stream_id, srate=srate)
             else:  # all other file formats
                 try:
                     self.model.load(fname)

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -107,7 +107,7 @@ class Model:
         data = read_raw(fname, *args, **kwargs, preload=True)
         argstr = ", " + f"{', '.join(f'{v}' for v in args)}" if args else ""
         if kwargs:
-            kwargstr = ", " + f"{', '.join(f'{k}={v}' for k, v in kwargs.items())}"
+            kwargstr = ", " + f"{', '.join(f'{k}={repr(v)}' for k, v in kwargs.items())}"
         else:
             kwargstr = ""
         self.history.append(f'data = read_raw("{fname}"{argstr}{kwargstr}, preload=True)')


### PR DESCRIPTION
By default, the effective sampling rate is used (but this can be changed by unchecking the option in the XDF import dialog).