### PR TITLE
Add option to prefix markers in XDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNRELEASED] - XXXX-XX-XX
 ### Added
 - Add option to use effective sampling rate when importing XDF files ([#236](https://github.com/cbrnr/mnelab/pull/236) by [Clemens Brunner](https://github.com/cbrnr))
+- Add option to disambiguate markers with identical names in different marker streams with the `prefix_markers` parameter ([#239](https://github.com/cbrnr/mnelab/pull/239) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
 - Fix history for importing XDF files and dropping channels ([#234](https://github.com/cbrnr/mnelab/pull/234) by [Clemens Brunner](https://github.com/cbrnr))


### PR DESCRIPTION
When there are two or more marker streams in an XDF file, it is possible that a specific marker type is present in more than one stream. This makes it impossible to disambiguate, for example a marker type `1` could be present in both marker streams with IDs 3 and 5.

This PR adds a `prefix_markers` parameter, which (when `True`) changes the annotation descriptions to `3-1` and `5-1`, respectively.