### PR TITLE
Setup Python in build-wheel job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
     - name: Build wheel
       run: pip wheel -w ~/.wheelhouse .
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
It is probably a good idea to set up Python in the build-wheel job. I'm not even sure why it was working without it before.