### PR TITLE
Better handle dots in XDF file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Add button in Append dialog that simplifies moving data between source and destination lists ([#242](https://github.com/cbrnr/mnelab/pull/242) by [Clemens Brunner](https://github.com/cbrnr))
 
+### Fixed
+- Fix loading of XDF files that contained additional dots in their file names ([#244](https://github.com/cbrnr/mnelab/pull/244) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [0.6.6] - 2021-11-19
 ### Added
 - Add option to use effective sampling rate when importing XDF files ([#236](https://github.com/cbrnr/mnelab/pull/236) by [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -392,7 +392,7 @@ class MainWindow(QMainWindow):
 
             ext = "".join(Path(fname).suffixes)
 
-            if ext in [".xdf", ".xdfz", ".xdf.gz"]:
+            if any([ext.endswith(e) for e in (".xdf", ".xdfz", ".xdf.gz")]):
                 from pyxdf import resolve_streams
                 rows, disabled = [], []
                 for idx, s in enumerate(resolve_streams(fname)):


### PR DESCRIPTION
Previously, XDF files containing additional dots (e.g. `abc.01.02.xdf`) could not be imported. This PR fixes this.