### PR TITLE
Add XDF chunk inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNRELEASED] - XXXX-XX-XX
 ### Added
 - Add button in Append dialog that simplifies moving data between source and destination lists ([#242](https://github.com/cbrnr/mnelab/pull/242) by [Clemens Brunner](https://github.com/cbrnr))
+- Add dialog that lists XDF chunks (File - Show XDF chunks...) which diplays chunk information for (possibly corrupted) XDF files ([#245](https://github.com/cbrnr/mnelab/pull/245) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
 - Fix loading of XDF files that contained additional dots in their file names ([#244](https://github.com/cbrnr/mnelab/pull/244) by [Clemens Brunner](https://github.com/cbrnr))

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ MNELAB requires Python >= 3.8 and the following packages:
 - [numpy](http://www.numpy.org/) >= 1.14.0
 - [scipy](https://www.scipy.org/scipylib/index.html) >= 1.0.0
 - [matplotlib](https://matplotlib.org/) >= 2.1.0
+- [pyxdf](https://github.com/xdf-modules/xdf-Python) >= 1.16.0
 - [pyobjc-framework-Cocoa](https://pyobjc.readthedocs.io/en/latest/) >= 5.2.0 (macOS only)
 
 Optional dependencies provide additional features if installed:
 - [scikit-learn](https://scikit-learn.org/stable/) >= 0.20.0 (ICA computation with FastICA)
 - [python-picard](https://pierreablin.github.io/picard/) >= 0.4.0 (ICA computation with PICARD)
-- [pyxdf](https://github.com/xdf-modules/xdf-Python) >= 1.16.0 (XDF import)
 - [pyEDFlib](https://github.com/holgern/pyedflib) >= 0.1.15 (EDF/BDF export)
 - [pybv](https://github.com/bids-standard/pybv) 0.4.0 (BrainVision VHDR/VMRK/EEG export)
 
@@ -38,7 +38,7 @@ pip install mnelab
 To use all MNELAB features, all optional dependencies should also be installed:
 
 ```
-pip install scikit-learn python-picard pyxdf pyEDFlib pybv
+pip install scikit-learn python-picard pyEDFlib pybv
 ```
 
 You can start MNELAB in a terminal with `mnelab` or `python -m mnelab`. On Windows, make sure to use Command Prompt (`cmd.exe`) or PowerShell (`powershell.exe`) &ndash; the `mnelab` command does not work in Git Bash.

--- a/mnelab/dialogs/__init__.py
+++ b/mnelab/dialogs/__init__.py
@@ -20,6 +20,7 @@ from .montagedialog import MontageDialog
 from .pickchannelsdialog import PickChannelsDialog
 from .referencedialog import ReferenceDialog
 from .runicadialog import RunICADialog
+from .xdfchunksdialog import XDFChunksDialog
 from .xdfstreamsdialog import XDFStreamsDialog
 
 
@@ -27,4 +28,4 @@ __all__ = ["AnnotationsDialog", "AppendDialog", "CalcDialog", "ChannelProperties
            "CropDialog", "EpochDialog", "ERDSDialog", "ErrorMessageBox", "EventsDialog",
            "FilterDialog", "FindEventsDialog", "HistoryDialog", "InterpolateBadsDialog",
            "MetaInfoDialog", "MontageDialog", "PickChannelsDialog", "ReferenceDialog",
-           "RunICADialog", "XDFStreamsDialog"]
+           "RunICADialog", "XDFChunksDialog", "XDFStreamsDialog"]

--- a/mnelab/dialogs/xdfchunksdialog.py
+++ b/mnelab/dialogs/xdfchunksdialog.py
@@ -1,0 +1,83 @@
+# Authors: Clemens Brunner <clemens.brunner@gmail.com>
+#
+# License: BSD (3-clause)
+
+from qtpy.QtCore import Qt, Slot
+from qtpy.QtGui import QFont, QStandardItem, QStandardItemModel
+from qtpy.QtWidgets import (QAbstractItemView, QDialog, QDialogButtonBox, QHBoxLayout,
+                            QPlainTextEdit, QTableView, QVBoxLayout)
+
+
+def _add_item(item):
+    tmp = QStandardItem()
+    tmp.setData(item, Qt.DisplayRole)
+    return tmp
+
+
+class XDFChunksDialog(QDialog):
+    def __init__(self, parent, chunks, fname):
+        super().__init__(parent)
+        self.setWindowTitle(f"XDF Chunks ({fname})")
+
+        self.chunks = chunks
+
+        TAGS = {1: "FileHeader", 2: "StreamHeader", 3: "Samples", 4: "ClockOffset",
+                5: "Boundary", 6: "StreamFooter"}
+
+        self.model = QStandardItemModel()
+        self.model.setHorizontalHeaderLabels(["#", "Bytes", "Tag", "Stream ID"])
+
+        for i, chunk in enumerate(chunks, start=1):
+            row = []
+            row.append(_add_item(i))
+            row.append(_add_item(chunk["nbytes"]))
+            row.append(_add_item(f"{chunk['tag']} ({TAGS[chunk['tag']]})"))
+            row.append(_add_item(chunk.get("stream_id", "")))
+            self.model.appendRow(row)
+
+        self.view = QTableView()
+        self.view.setModel(self.model)
+        self.view.verticalHeader().setVisible(False)
+        self.view.horizontalHeader().setStretchLastSection(True)
+        self.view.setShowGrid(False)
+        self.view.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.view.setSortingEnabled(True)
+        self.view.sortByColumn(0, Qt.AscendingOrder)
+        self.view.setEditTriggers(QTableView.NoEditTriggers)
+        self.view.setFixedWidth(450)
+
+        self.details = QPlainTextEdit("")
+        self.details.setFixedWidth(450)
+        self.details.setReadOnly(True)
+        self.details.setTabStopDistance(30)
+        font = QFont()
+        font.setFamily("monospace")
+        font.setStyleHint(QFont.Monospace)
+        self.details.setFont(font)
+        self.details.setLineWrapMode(QPlainTextEdit.NoWrap)
+
+        hbox = QHBoxLayout()
+        hbox.addWidget(self.view)
+        hbox.addWidget(self.details)
+
+        vbox = QVBoxLayout(self)
+        vbox.addLayout(hbox)
+        self.buttonbox = QDialogButtonBox(QDialogButtonBox.Ok)
+        vbox.addWidget(self.buttonbox)
+        self.buttonbox.accepted.connect(self.accept)
+
+        self.view.clicked.connect(self._update_details)
+
+        self.setFixedSize(980, 650)
+        self.view.setColumnWidth(0, 70)
+        self.view.setColumnWidth(1, 80)
+        self.view.setColumnWidth(2, 150)
+        self.view.setColumnWidth(3, 70)
+
+    @Slot()
+    def _update_details(self):
+        selection = self.view.selectionModel()
+        if selection.hasSelection():
+            n = int(selection.selectedIndexes()[0].data())
+            self.details.setPlainText(self.chunks[n - 1].get("content", ""))

--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -7,7 +7,6 @@ from functools import partial
 
 import mne
 
-from ..utils import have
 from .xdf import read_raw_xdf
 
 
@@ -32,12 +31,10 @@ supported = {".edf": mne.io.read_raw_edf,
              ".mff": mne.io.read_raw_egi,
              ".nxe": mne.io.read_raw_eximia,
              ".hdr": mne.io.read_raw_nirx,
-             ".snirf": mne.io.read_raw_snirf}
-
-if have["pyxdf"]:
-    supported.update({".xdf": read_raw_xdf,
-                      ".xdfz": read_raw_xdf,
-                      ".xdf.gz": read_raw_xdf})
+             ".snirf": mne.io.read_raw_snirf,
+             ".xdf": read_raw_xdf,
+             ".xdfz": read_raw_xdf,
+             ".xdf.gz": read_raw_xdf}
 
 # known but unsupported file formats
 suggested = {".vmrk": partial(_read_unsupported, suggest=".vhdr"),

--- a/mnelab/utils/dependencies.py
+++ b/mnelab/utils/dependencies.py
@@ -6,8 +6,8 @@ from importlib import import_module
 from qtpy import API_NAME
 
 
-required = ["mne", "numpy", "scipy", "matplotlib", "qtpy", API_NAME]
-optional = ["sklearn", "picard", "pyedflib", "pyxdf", "pybv"]
+required = ["mne", "numpy", "scipy", "matplotlib", "qtpy", "pyxdf", API_NAME]
+optional = ["sklearn", "picard", "pyedflib", "pybv"]
 
 have = {}
 for package in required + optional:

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,7 +1,6 @@
 scikit-learn>=0.20.0  # fastica
 python-picard>=0.4.0  # picard
 pyEDFlib>=0.1.15  # edf
-pyxdf>=1.16.0  # xdf
 pybv>=0.4.0  # brainvision
 PyQt5>=5.10.0  # pyqt5
 PySide2>=5.10.0  # pyside2

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     numpy>=1.14.0
     scipy>=1.0.0
     matplotlib>=2.1.0
+    pyxdf>=1.16.0
     pyobjc-framework-Cocoa>=5.2.0; platform_system=="Darwin"
 
 [options.extras_require]
@@ -33,7 +34,6 @@ full =
     scikit-learn>=0.20.0  # fastica
     python-picard>=0.4.0  # picard
     pyEDFlib>=0.1.15  # edf
-    pyxdf>=1.16.0  # xdf
     pybv>=0.4.0  # brainvision
     PyQt5>=5.10.0  # pyqt5
     PySide2>=5.10.0  # pyside2


### PR DESCRIPTION
This adds a new dialog window "File–Show XDF chunks...", which lists all chunks contained in an XDF file with some basic information. This also works with corrupted XDF files, so this might be useful to find out what data can be saved from an invalid file.

With this change, `pyxdf` will be a required dependency.