### PR TITLE
Improve supported file extension detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Add dialog that lists XDF chunks (File - Show XDF chunks...) which diplays chunk information for (possibly corrupted) XDF files ([#245](https://github.com/cbrnr/mnelab/pull/245) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
-- Fix loading of XDF files that contained additional dots in their file names ([#244](https://github.com/cbrnr/mnelab/pull/244) by [Clemens Brunner](https://github.com/cbrnr))
+- Fix loading of XDF files that contained additional dots in their file names ([#244](https://github.com/cbrnr/mnelab/pull/244) and [#246](https://github.com/cbrnr/mnelab/pull/246) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.6.6] - 2021-11-19
 ### Added

--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -44,6 +44,16 @@ suggested = {".vmrk": partial(_read_unsupported, suggest=".vhdr"),
 readers = {**supported, **suggested}
 
 
+def split_name_ext(fname):
+    """Return name and supported file extension."""
+    maxsuffixes = max([ext.count(".") for ext in supported])
+    suffixes = Path(fname).suffixes
+    for i in range(-maxsuffixes, 0):
+        ext = "".join(suffixes[i:]).lower()
+        if ext in readers.keys():
+            return fname.removesuffix(ext), ext
+
+
 def read_raw(fname, *args, **kwargs):
     """Read raw file.
 
@@ -62,12 +72,9 @@ def read_raw(fname, *args, **kwargs):
     This function supports reading different file formats. It uses the readers dict to
     dispatch the appropriate read function for a supported file type.
     """
-    maxsuffixes = max([ext.count(".") for ext in supported])
-    suffixes = Path(fname).suffixes
-    for i in range(-maxsuffixes, 0):
-        ext = "".join(suffixes[i:]).lower()
-        if ext in readers.keys():
-            return readers[ext](fname, *args, **kwargs)
-    raise ValueError(f"Unknown file type {suffixes}.")
+    _, ext = split_name_ext(fname)
+    if ext is not None:
+        return readers[ext](fname, *args, **kwargs)
+    raise ValueError(f"Unknown file type {''.join(Path(fname).suffixes)}).")
     # here we could inspect the file signature to determine its type, which would allow us
     # to read file independently of their extensions

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -3,7 +3,6 @@
 # License: BSD (3-clause)
 
 from os.path import getsize, join, split, splitext
-from pathlib import Path
 from collections import Counter, defaultdict
 from functools import wraps
 from copy import deepcopy
@@ -13,6 +12,7 @@ import mne
 
 from .utils import has_locations
 from .io import read_raw, write_raw
+from .io.readers import split_name_ext
 
 
 class LabelsNotFoundError(Exception):
@@ -113,7 +113,7 @@ class Model:
         self.history.append(f'data = read_raw("{fname}"{argstr}{kwargstr}, preload=True)'.
                             replace("'", '"'))
         fsize = getsize(data.filenames[0]) / 1024**2  # convert to MB
-        name, ext = Path(fname).stem, "".join(Path(fname).suffixes)
+        name, ext = split_name_ext(fname)
         self.insert_data(defaultdict(lambda: None, name=name, fname=fname,
                                      ftype=ext.upper()[1:], fsize=fsize, data=data,
                                      dtype="raw"))


### PR DESCRIPTION
Previously, files with more than one dot have not been recognized correctly. This is an extension of #244, which failed to fix `ftype` shown in the MNELAB info widget.