### PR TITLE
Fix: Split file extension with py38 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [UNRELEASED] - XXXX-XX-XX
-### Fixed 
-- Fix splitting name and extension of XDF files for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))
+### Fixed
+- Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))
 
 ## [0.7.0] - 2021-12-29
 ### Added

--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -47,11 +47,12 @@ readers = {**supported, **suggested}
 def split_name_ext(fname):
     """Return name and supported file extension."""
     maxsuffixes = max([ext.count(".") for ext in supported])
-    suffixes = Path(fname).suffixes
+    fpath = Path(fname)
+    suffixes = fpath.suffixes
     for i in range(-maxsuffixes, 0):
         ext = "".join(suffixes[i:]).lower()
         if ext in readers.keys():
-            return fname.removesuffix(ext), ext
+            return str(fpath.with_suffix("")), ext
 
 
 def read_raw(fname, *args, **kwargs):

--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -47,12 +47,11 @@ readers = {**supported, **suggested}
 def split_name_ext(fname):
     """Return name and supported file extension."""
     maxsuffixes = max([ext.count(".") for ext in supported])
-    fpath = Path(fname)
-    suffixes = fpath.suffixes
+    suffixes = Path(fname).suffixes
     for i in range(-maxsuffixes, 0):
         ext = "".join(suffixes[i:]).lower()
         if ext in readers.keys():
-            return str(fpath.with_suffix("")), ext
+            return fname[:-len(ext)], ext
 
 
 def read_raw(fname, *args, **kwargs):

--- a/mnelab/test/test_readers.py
+++ b/mnelab/test/test_readers.py
@@ -1,0 +1,12 @@
+import pytest
+from mnelab.io.readers import split_name_ext, supported
+
+
+@pytest.mark.parametrize("ext", supported.keys())
+def test_split_name_ext(ext):
+    fname = f"test{ext}"
+    assert split_name_ext(fname) == ("test", ext)
+
+
+def test_split_name_ext_unsupported():
+    assert split_name_ext("test.xxx") is None


### PR DESCRIPTION
Fixes issue #251.
Previously, loading XDF files with Python 3.8 resulted in an error due to usage of `removesuffix` (Python 3.9+). This PR fixes the problem by using `pathlib.Path.with_suffix`. 