### PR TITLE
Make dataset overwrite dialog more explicit

### DIFF
--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -875,15 +875,14 @@ class MainWindow(QMainWindow):
             self.model.duplicate_data()
             return True
         # otherwise ask the user
-        else:
-            msg = QMessageBox.question(
-                self,
-                "Create new data set",
-                "Create new data set?\nIf 'No', the current data set is overwritten.",
-            )
-            if msg == QMessageBox.Yes:  # create new data set
-                self.model.duplicate_data()
-                return True
+        msg = QMessageBox.question(
+            self,
+            "Create new data set",
+            "Create new data set?\nIf 'No', the current data set is overwritten.",
+        )
+        if msg == QMessageBox.Yes:  # create new data set
+            self.model.duplicate_data()
+            return True
         return False
 
     def _add_recent(self, fname):

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -876,10 +876,10 @@ class MainWindow(QMainWindow):
             return True
         # otherwise ask the user
         msg = QMessageBox()
-        msg.setWindowTitle("Create new data set")
-        msg.setText("Create new data set?")
+        msg.setWindowTitle("Modify data set")
+        msg.setText("You are about to modify the current data set. How do you want to proceed?")  # noqa: E501
         msg.addButton("Create new data set", QMessageBox.YesRole)
-        msg.addButton("Overwrite existing data set", QMessageBox.NoRole)
+        msg.addButton("Overwrite current data set", QMessageBox.NoRole)
         if msg.exec() == 0:  # create new data set (button index 0)
             self.model.duplicate_data()
             return True

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -880,6 +880,7 @@ class MainWindow(QMainWindow):
         msg.setText("You are about to modify the current data set. How do you want to proceed?")  # noqa: E501
         createnew_button = msg.addButton("Create new data set", QMessageBox.YesRole)
         msg.addButton("Overwrite current data set", QMessageBox.NoRole)
+        msg.setDefaultButton(createnew_button)
         msg.exec()
         if msg.clickedButton() == createnew_button:
             self.model.duplicate_data()

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -875,12 +875,12 @@ class MainWindow(QMainWindow):
             self.model.duplicate_data()
             return True
         # otherwise ask the user
-        msg = QMessageBox.question(
-            self,
-            "Create new data set",
-            "Create new data set?\nIf 'No', the current data set is overwritten.",
-        )
-        if msg == QMessageBox.Yes:  # create new data set
+        msg = QMessageBox()
+        msg.setWindowTitle("Create new data set")
+        msg.setText("Create new data set?")
+        msg.addButton("Create new data set", QMessageBox.YesRole)
+        msg.addButton("Overwrite existing data set", QMessageBox.NoRole)
+        if msg.exec() == 0:  # create new data set (button index 0)
             self.model.duplicate_data()
             return True
         return False

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -878,9 +878,10 @@ class MainWindow(QMainWindow):
         msg = QMessageBox()
         msg.setWindowTitle("Modify data set")
         msg.setText("You are about to modify the current data set. How do you want to proceed?")  # noqa: E501
-        msg.addButton("Create new data set", QMessageBox.YesRole)
+        createnew_button = msg.addButton("Create new data set", QMessageBox.YesRole)
         msg.addButton("Overwrite current data set", QMessageBox.NoRole)
-        if msg.exec() == 0:  # create new data set (button index 0)
+        msg.exec()
+        if msg.clickedButton() == createnew_button:
             self.model.duplicate_data()
             return True
         return False

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -876,9 +876,12 @@ class MainWindow(QMainWindow):
             return True
         # otherwise ask the user
         else:
-            msg = QMessageBox.question(self, "Overwrite existing data set",
-                                       "Overwrite existing data set?")
-            if msg == QMessageBox.No:  # create new data set
+            msg = QMessageBox.question(
+                self,
+                "Create new data set",
+                "Create new data set?\nIf 'No', the current data set is overwritten.",
+            )
+            if msg == QMessageBox.Yes:  # create new data set
                 self.model.duplicate_data()
                 return True
         return False


### PR DESCRIPTION
When closed, the dialog falls back to "No", so by default a new dataset is created.
Resolves #103