### PR TITLE
Enhance "Set reference"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Add support to select and load multiple files at once ([#257](https://github.com/cbrnr/mnelab/pull/257) by [Florian Hofer](https://github.com/hofaflo))
 
+### Changed
+- Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))
+
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))
 

--- a/mnelab/dialogs/referencedialog.py
+++ b/mnelab/dialogs/referencedialog.py
@@ -2,74 +2,80 @@
 #
 # License: BSD (3-clause)
 
-from PySide6.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox,
-                               QGridLayout, QLineEdit, QRadioButton,
-                               QVBoxLayout)
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QGridLayout,
+                               QGroupBox, QLabel, QLineEdit, QListWidget,
+                               QRadioButton, QVBoxLayout)
 
 
 class ReferenceDialog(QDialog):
-    def __init__(self, parent):
+    def __init__(self, parent, available_channels):
         super().__init__(parent)
-        self.setWindowTitle("Modify reference")
+        self.setWindowTitle("Change reference")
         vbox = QVBoxLayout(self)
-        grid = QGridLayout()
 
-        self.add_reference = QCheckBox("Add reference channel(s):")
+        self.add_group = QGroupBox("Add reference (all zero)")
+        self.reref_group = QGroupBox("Re-reference to existing channel(s)")
+
+        vbox.addWidget(self.add_group)
+        vbox.addWidget(self.reref_group)
+
+        self.add_group.setCheckable(True)
+        self.reref_group.setCheckable(True)
+
+        self.add_group.setChecked(False)
 
         self.add_channellist = QLineEdit()
-        self.add_channellist.setEnabled(False)
+        add_grid = QGridLayout()
+        add_grid.setColumnStretch(0, 2)
+        add_grid.setColumnStretch(1, 3)
+        add_grid.addWidget(QLabel("Channel(s):"), 0, 0)
+        add_grid.addWidget(self.add_channellist, 0, 1)
+        self.add_group.setLayout(add_grid)
 
-        self.set_reference = QCheckBox("Set EEG reference:")
+        self.reref_average = QRadioButton("Average")
+        self.reref_channels = QRadioButton("Channel(s):")
+        self.reref_channellist = QListWidget()
+        self.reref_channellist.insertItems(0, available_channels)
+        self.reref_average.setChecked(True)
+        self.reref_channellist.setEnabled(False)
+        self.reref_channellist.setSelectionMode(QListWidget.ExtendedSelection)
+        reref_grid = QGridLayout()
+        reref_grid.setColumnStretch(0, 2)
+        reref_grid.setColumnStretch(1, 3)
+        reref_grid.addWidget(self.reref_average, 0, 0)
+        reref_grid.addWidget(self.reref_channels, 1, 0, alignment=Qt.AlignTop)
+        reref_grid.addWidget(self.reref_channellist, 1, 1)
 
-        self.average = QRadioButton("Average")
-        self.set_channels = QRadioButton("Channel(s):")
+        self.reref_group.setLayout(reref_grid)
 
-        self.set_channellist = QLineEdit()
+        self.reref_channels.toggled.connect(self.toggle_reref_channellist)
+        self.add_group.toggled.connect(self.toggle_ok)
+        self.add_channellist.textChanged.connect(self.toggle_ok)
+        self.reref_group.toggled.connect(self.toggle_ok)
+        self.reref_channels.toggled.connect(self.toggle_ok)
+        self.reref_channellist.itemSelectionChanged.connect(self.toggle_ok)
 
-        self.add_channellist.setEnabled(False)
-        self.set_reference.setChecked(True)
-        self.average.setChecked(True)
-        self.set_channellist.setEnabled(False)
-
-        self.add_reference.toggled.connect(self.toggle_add_channellist)
-        self.set_reference.toggled.connect(self.toggle_set)
-        self.set_channels.toggled.connect(self.toggle_set_channellist)
-        self.add_reference.toggled.connect(self.toggle_ok)
-        self.set_reference.toggled.connect(self.toggle_ok)
-
-        grid.addWidget(self.add_reference, 0, 0)
-        grid.addWidget(self.add_channellist, 0, 1)
-
-        grid.addWidget(self.set_reference, 1, 0)
-
-        grid.addWidget(self.average, 2, 0)
-
-        grid.addWidget(self.set_channels, 3, 0)
-        grid.addWidget(self.set_channellist, 3, 1)
-
-        vbox.addLayout(grid)
         self.buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         vbox.addWidget(self.buttonbox)
         self.buttonbox.accepted.connect(self.accept)
         self.buttonbox.rejected.connect(self.reject)
         vbox.setSizeConstraint(QVBoxLayout.SetFixedSize)
 
-    def toggle_set(self):
-        for element in (
-            self.average,
-            self.set_channels,
-            self.set_channellist,
-        ):
-            element.setEnabled(self.set_reference.isChecked())
-
-    def toggle_add_channellist(self):
-        self.add_channellist.setEnabled(self.add_reference.isChecked())
-
-    def toggle_set_channellist(self):
-        self.set_channellist.setEnabled(self.set_channels.isChecked())
+    def toggle_reref_channellist(self):
+        self.reref_channellist.setEnabled(self.reref_channels.isChecked())
 
     def toggle_ok(self):
-        self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(
-            self.add_reference.isChecked()
-            or self.set_reference.isChecked()
-        )
+        if self.add_group.isChecked() and not self.add_channellist.text():
+            self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(False)
+            return
+
+        if not self.add_group.isChecked() and not self.reref_group.isChecked():
+            self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(False)
+            return
+
+        if self.reref_group.isChecked() and self.reref_channels.isChecked() and not self.reref_channellist.selectedItems():  # noqa: E501
+            self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(False)
+            return
+
+        self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(True)

--- a/mnelab/dialogs/referencedialog.py
+++ b/mnelab/dialogs/referencedialog.py
@@ -34,6 +34,8 @@ class ReferenceDialog(QDialog):
         self.add_reference.toggled.connect(self.toggle_add_channellist)
         self.set_reference.toggled.connect(self.toggle_set)
         self.set_channels.toggled.connect(self.toggle_set_channellist)
+        self.add_reference.toggled.connect(self.toggle_ok)
+        self.set_reference.toggled.connect(self.toggle_ok)
 
         grid.addWidget(self.add_reference, 0, 0)
         grid.addWidget(self.add_channellist, 0, 1)
@@ -46,10 +48,10 @@ class ReferenceDialog(QDialog):
         grid.addWidget(self.set_channellist, 3, 1)
 
         vbox.addLayout(grid)
-        buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        vbox.addWidget(buttonbox)
-        buttonbox.accepted.connect(self.accept)
-        buttonbox.rejected.connect(self.reject)
+        self.buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        vbox.addWidget(self.buttonbox)
+        self.buttonbox.accepted.connect(self.accept)
+        self.buttonbox.rejected.connect(self.reject)
         vbox.setSizeConstraint(QVBoxLayout.SetFixedSize)
 
     def toggle_set(self):
@@ -65,3 +67,9 @@ class ReferenceDialog(QDialog):
 
     def toggle_set_channellist(self):
         self.set_channellist.setEnabled(self.set_channels.isChecked())
+
+    def toggle_ok(self):
+        self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(
+            self.add_reference.isChecked()
+            or self.set_reference.isChecked()
+        )

--- a/mnelab/dialogs/referencedialog.py
+++ b/mnelab/dialogs/referencedialog.py
@@ -2,25 +2,49 @@
 #
 # License: BSD (3-clause)
 
-from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QGridLayout, QLineEdit,
-                               QRadioButton, QVBoxLayout)
+from PySide6.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox,
+                               QGridLayout, QLineEdit, QRadioButton,
+                               QVBoxLayout)
 
 
 class ReferenceDialog(QDialog):
     def __init__(self, parent):
         super().__init__(parent)
-        self.setWindowTitle("Set reference")
+        self.setWindowTitle("Modify reference")
         vbox = QVBoxLayout(self)
         grid = QGridLayout()
+
+        self.add_reference = QCheckBox("Add reference channel(s):")
+
+        self.add_channellist = QLineEdit()
+        self.add_channellist.setEnabled(False)
+
+        self.set_reference = QCheckBox("Set EEG reference:")
+
         self.average = QRadioButton("Average")
-        self.channels = QRadioButton("Channel(s):")
-        self.average.toggled.connect(self.toggle)
-        self.channellist = QLineEdit()
-        self.channellist.setEnabled(False)
+        self.set_channels = QRadioButton("Channel(s):")
+
+        self.set_channellist = QLineEdit()
+
+        self.add_channellist.setEnabled(False)
+        self.set_reference.setChecked(True)
         self.average.setChecked(True)
-        grid.addWidget(self.average, 0, 0)
-        grid.addWidget(self.channels, 1, 0)
-        grid.addWidget(self.channellist, 1, 1)
+        self.set_channellist.setEnabled(False)
+
+        self.add_reference.toggled.connect(self.toggle_add_channellist)
+        self.set_reference.toggled.connect(self.toggle_set)
+        self.set_channels.toggled.connect(self.toggle_set_channellist)
+
+        grid.addWidget(self.add_reference, 0, 0)
+        grid.addWidget(self.add_channellist, 0, 1)
+
+        grid.addWidget(self.set_reference, 1, 0)
+
+        grid.addWidget(self.average, 2, 0)
+
+        grid.addWidget(self.set_channels, 3, 0)
+        grid.addWidget(self.set_channellist, 3, 1)
+
         vbox.addLayout(grid)
         buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         vbox.addWidget(buttonbox)
@@ -28,8 +52,16 @@ class ReferenceDialog(QDialog):
         buttonbox.rejected.connect(self.reject)
         vbox.setSizeConstraint(QVBoxLayout.SetFixedSize)
 
-    def toggle(self):
-        if self.average.isChecked():
-            self.channellist.setEnabled(False)
-        else:
-            self.channellist.setEnabled(True)
+    def toggle_set(self):
+        for element in (
+            self.average,
+            self.set_channels,
+            self.set_channellist,
+        ):
+            element.setEnabled(self.set_reference.isChecked())
+
+    def toggle_add_channellist(self):
+        self.add_channellist.setEnabled(self.add_reference.isChecked())
+
+    def toggle_set_channellist(self):
+        self.set_channellist.setEnabled(self.set_channels.isChecked())

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -825,7 +825,7 @@ class MainWindow(QMainWindow):
                 if dialog.reref_average.isChecked():
                     ref = "average"
                 else:
-                    ref = [c.strip() for c in dialog.reref_channellist.text().split(",")]
+                    ref = [c.text() for c in dialog.reref_channellist.selectedItems()]
             else:
                 ref = None
             duplicated = self.auto_duplicate()

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -161,8 +161,10 @@ class MainWindow(QMainWindow):
         self.actions["set_montage"] = edit_menu.addAction("Set &montage...",
                                                           self.set_montage)
         edit_menu.addSeparator()
-        self.actions["set_ref"] = edit_menu.addAction("Set &reference...",
-                                                      self.set_reference)
+        self.actions["modify_ref"] = edit_menu.addAction(
+            "Modify &reference...",
+            self.modify_reference,
+        )
         edit_menu.addSeparator()
         self.actions["annotations"] = edit_menu.addAction("&Annotations...",
                                                           self.edit_annotations)
@@ -811,16 +813,23 @@ class MainWindow(QMainWindow):
         self.auto_duplicate()
         self.model.convert_beer_lambert()
 
-    def set_reference(self):
-        """Set reference."""
+    def modify_reference(self):
+        """Modify reference."""
         dialog = ReferenceDialog(self)
         if dialog.exec():
             self.auto_duplicate()
-            if dialog.average.isChecked():
-                self.model.set_reference("average")
+            if dialog.add_reference.isChecked():
+                add = [c.strip() for c in dialog.add_channellist.text().split(",")]
             else:
-                ref = [c.strip() for c in dialog.channellist.text().split(",")]
-                self.model.set_reference(ref)
+                add = []
+            if dialog.set_reference.isChecked():
+                if dialog.average.isChecked():
+                    ref = "average"
+                else:
+                    ref = [c.strip() for c in dialog.set_channellist.text().split(",")]
+            else:
+                ref = None
+            self.model.modify_reference(add, ref)
 
     def show_history(self):
         """Show history."""

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -472,15 +472,11 @@ class Model:
         self.history.append("data = mne.preprocessing.nirs.beer_lambert_law(data)")
 
     @data_changed
-    def modify_reference(self, add, ref):
+    def change_reference(self, add, ref):
         self.current["reference"] = ref
         if add:
-            try:
-                mne.add_reference_channels(self.current["data"], add, copy=False)
-            except RuntimeError:
-                raise AddReferenceError(f"Cannot add reference channels {add}.")
-            else:
-                self.history.append(f"mne.add_reference_channels(data, {add}, copy=False)")
+            mne.add_reference_channels(self.current["data"], add, copy=False)
+            self.history.append(f"mne.add_reference_channels(data, {add}, copy=False)")
         if ref is None:
             return
 

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -472,28 +472,25 @@ class Model:
         self.history.append("data = mne.preprocessing.nirs.beer_lambert_law(data)")
 
     @data_changed
-    def set_reference(self, ref):
+    def modify_reference(self, add, ref):
+        self.current["reference"] = ref
+        if add:
+            try:
+                mne.add_reference_channels(self.current["data"], add, copy=False)
+            except RuntimeError:
+                raise AddReferenceError(f"Cannot add reference channels {add}.")
+            else:
+                self.history.append(f"mne.add_reference_channels(data, {add}, copy=False)")
+        if ref is None:
+            return
+
         self.current["reference"] = ref
         if ref == "average":
             self.current["name"] += " (average ref)"
-            self.current["data"].set_eeg_reference(ref)
-            self.history.append('data.set_eeg_reference("average")')
         else:
             self.current["name"] += " (" + ",".join(ref) + ")"
-            if set(ref) - set(self.current["data"].info["ch_names"]):
-                # add new reference channel(s) to data
-                try:
-                    mne.add_reference_channels(self.current["data"], ref, copy=False)
-                except RuntimeError:
-                    raise AddReferenceError("Cannot add reference channels to average "
-                                            "reference signals.")
-                else:
-                    self.history.append(f"mne.add_reference_channels(data, {ref}, "
-                                        f"copy=False)")
-            else:
-                # re-reference to existing channel(s)
-                self.current["data"].set_eeg_reference(ref)
-                self.history.append(f"data.set_eeg_reference({ref})")
+        self.current["data"].set_eeg_reference(ref)
+        self.history.append(f"data.set_eeg_reference({ref!r})")
 
     @data_changed
     def set_events(self, events):


### PR DESCRIPTION
Currently, if the data set does not contain the reference channel, rereferencing requires to open "Set reference..." twice:
- first, to add the reference channel
- second, to actually rereference to the desired channel(s)

Example, following [this](https://github.com/cbrnr/bci_event_2021#erders-analysis-with-mnelab) tutorial:
![image](https://user-images.githubusercontent.com/22592497/152706993-03c0a7da-7fcb-43bc-80e4-3be820e21c74.png)
![image](https://user-images.githubusercontent.com/22592497/152707001-f8e02c3b-9b4d-42dc-b809-3fcb72e198aa.png)


Here's an idea what the dialog could look like to perform both steps at once (called "Modify reference" to reflect both possible actions):
![image](https://user-images.githubusercontent.com/22592497/152706955-8b0040ca-eb73-4cf2-90c4-318c514466ca.png)

This could be the initial state:
![image](https://user-images.githubusercontent.com/22592497/152707037-e59ec4db-f3f1-4e95-b146-5ec28853213c.png)

And only adding a reference channel, without rereferencing would still be possible:
![image](https://user-images.githubusercontent.com/22592497/152707057-dbd34d50-2f00-4331-87b5-4c86da2ff828.png)
