### PR TITLE
Add drag and drop reordering to sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNRELEASED] - XXXX-XX-XX
 ### Added
 - Add support to select and load multiple files at once ([#257](https://github.com/cbrnr/mnelab/pull/257) by [Florian Hofer](https://github.com/hofaflo))
+- Add drag and drop reordering to sidebar ([#260](https://github.com/cbrnr/mnelab/pull/260) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [UNRELEASED] - XXXX-XX-XX
+### Added
+- Add support to select and load multiple files at once ([#257](https://github.com/cbrnr/mnelab/pull/257) by [Florian Hofer](https://github.com/hofaflo))
+
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))
 

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -875,12 +875,16 @@ class MainWindow(QMainWindow):
             self.model.duplicate_data()
             return True
         # otherwise ask the user
-        else:
-            msg = QMessageBox.question(self, "Overwrite existing data set",
-                                       "Overwrite existing data set?")
-            if msg == QMessageBox.No:  # create new data set
-                self.model.duplicate_data()
-                return True
+        msg = QMessageBox()
+        msg.setWindowTitle("Modify data set")
+        msg.setText("You are about to modify the current data set. How do you want to proceed?")  # noqa: E501
+        createnew_button = msg.addButton("Create new data set", QMessageBox.YesRole)
+        msg.addButton("Overwrite current data set", QMessageBox.NoRole)
+        msg.setDefaultButton(createnew_button)
+        msg.exec()
+        if msg.clickedButton() == createnew_button:
+            self.model.duplicate_data()
+            return True
         return False
 
     def _add_recent(self, fname):

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -310,14 +310,14 @@ class MainWindow(QMainWindow):
 
     def _sidebar_move_event(self, parent, start, end, destination, row):
         """
-        Triggered when an data set in the sidebar is moved.
+        Triggered when an item in the sidebar is moved.
 
         Parameters
         ----------
         parent : PySide6.QtCore.QModelIndex
             ???
         start : int
-            The source index of the data set.
+            The source index of the item.
         end : int
             Same as start because the sidebar only allows single selection.
         destination : PySide6.QtCore.QModelIndex
@@ -325,20 +325,7 @@ class MainWindow(QMainWindow):
         row : int
             The target index.
         """
-        # first the data set is copied to the target index
-        self.model.data.insert(row, self.model.data[start])
-        self.model.history.append(f"datasets.insert({row}, datasets[{start}]")
-        # if moved upward, the source index is increased by 1
-        if start > row:
-            start += 1
-        # if moved downward, the new index (after removing the original
-        # item) will be 1 less that the target index
-        else:
-            row -= 1
-        self.model.index = row
-        self.model.data.pop(start)
-        self.model.history.append(f"datasets.pop({start})]")
-        self.data_changed()
+        self.model.move_data_set(start, row)
 
     def data_changed(self):
         # update sidebar

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -315,13 +315,13 @@ class MainWindow(QMainWindow):
         Parameters
         ----------
         parent : PySide6.QtCore.QModelIndex
-            ???
+            Unused.
         start : int
             The source index of the item.
         end : int
-            Same as start because the sidebar only allows single selection.
+            Unused (equals start as the sidebar only allows single selection).
         destination : PySide6.QtCore.QModelIndex
-            ???
+            Unused.
         row : int
             The target index.
         """

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -385,8 +385,11 @@ class MainWindow(QMainWindow):
     def open_data(self, fname=None):
         """Open raw file."""
         if fname is None:
-            fname = QFileDialog.getOpenFileName(self, "Open raw")[0]
-        if fname:
+            # getOpenFileNames returns a tuple (filenames, selected_filter)
+            fnames, _ = QFileDialog.getOpenFileNames(self, "Open raw")
+        else:
+            fnames = [fname]
+        for fname in fnames:
             if not (Path(fname).is_file() or Path(fname).is_dir()):
                 self._remove_recent(fname)
                 QMessageBox.critical(self, "File does not exist",

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -502,3 +502,29 @@ class Model:
     @data_changed
     def set_annotations(self, onset, duration, description):
         self.current["data"].set_annotations(mne.Annotations(onset, duration, description))
+
+    @data_changed
+    def move_data_set(self, source, target):
+        """
+        Change the position of a single data set in `self.data`.
+
+        Parameters
+        ----------
+        source : int
+            The data set's initial index.
+        target : int
+            The index the data set should be moved to.
+        """
+        # first the data set is copied to the target index
+        self.data.insert(target, self.data[source])
+        self.history.append(f"datasets.insert({target}, datasets[{source}])")
+        # if moved to the front, the source index is increased by 1
+        if source > target:
+            source += 1
+        # if moved to the back, the new index (after removing the original
+        # data set) will be 1 less that the target index
+        else:
+            target -= 1
+        self.index = target
+        self.data.pop(source)
+        self.history.append(f"datasets.pop({source})")


### PR DESCRIPTION
I didn't get the `QListView` to allow dropping items only between others, not onto them, so this replaces the sidebar's `QListView` and `QStringListModel` with a `QListWidget`. I'm not sure if this could break something?

The following things work:
- drag and drop reorder (+history)
- data set renaming

@cbrnr, does any missing functionality come to mind?

If not, this fixes #128 :)