### PR TITLE
Move XDF info to file menu and add XDF streams details button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Add support to select and load multiple files at once ([#257](https://github.com/cbrnr/mnelab/pull/257) by [Florian Hofer](https://github.com/hofaflo))
 - Add drag and drop reordering to sidebar ([#261](https://github.com/cbrnr/mnelab/pull/261) by [Florian Hofer](https://github.com/hofaflo))
 - Add support for plotting evoked potentials averaged over channels (Plot -> Evoked comparison...) ([#256](https://github.com/cbrnr/mnelab/pull/256) by [Florian Hofer](https://github.com/hofaflo))
+- Add "Details..." button to "Select XDF Stream" dialog ([#266](https://github.com/cbrnr/mnelab/pull/266) by [Florian Hofer](https://github.com/hofaflo))
+
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))
+- Move "Show information..." from toolbar to "File" menu and rename to "Show XDF meta information" ([#266](https://github.com/cbrnr/mnelab/pull/266) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))

--- a/mnelab/dialogs/meta_info.py
+++ b/mnelab/dialogs/meta_info.py
@@ -20,7 +20,7 @@ def populate_tree(parent, node):
 class MetaInfoDialog(QDialog):
     def __init__(self, parent, xml):
         super().__init__(parent)
-        self.setWindowTitle("Information")
+        self.setWindowTitle("XDF meta information")
 
         tree = QTreeWidget()
         tree.setColumnCount(2)

--- a/mnelab/dialogs/xdf_streams.py
+++ b/mnelab/dialogs/xdf_streams.py
@@ -53,7 +53,7 @@ class XDFStreamsDialog(QDialog):
         if not disabled:
             self._prefix_markers.setEnabled(False)
         hbox.addWidget(self._prefix_markers)
-        self.details_button = QPushButton("Details...")
+        self.details_button = QPushButton("Details")
         self.details_button.clicked.connect(self.details)
         hbox.addWidget(self.details_button)
         vbox.addLayout(hbox)

--- a/mnelab/dialogs/xdf_streams.py
+++ b/mnelab/dialogs/xdf_streams.py
@@ -5,13 +5,14 @@
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItem, QStandardItemModel
 from PySide6.QtWidgets import (QAbstractItemView, QCheckBox, QDialog, QDialogButtonBox,
-                               QHBoxLayout, QTableView, QVBoxLayout)
+                               QHBoxLayout, QTableView, QVBoxLayout, QPushButton)
 
 
 class XDFStreamsDialog(QDialog):
-    def __init__(self, parent, rows, selected=None, disabled=None):
+    def __init__(self, parent, rows, fname, selected=None, disabled=None):
         super().__init__(parent)
         self.setWindowTitle("Select XDF Stream")
+        self.fname = fname
 
         self.model = QStandardItemModel()
         self.model.setHorizontalHeaderLabels(["ID", "Name", "Type", "Channels", "Format",
@@ -52,7 +53,11 @@ class XDFStreamsDialog(QDialog):
         if not disabled:
             self._prefix_markers.setEnabled(False)
         hbox.addWidget(self._prefix_markers)
+        self.details_button = QPushButton("Details...")
+        self.details_button.clicked.connect(self.details)
+        hbox.addWidget(self.details_button)
         vbox.addLayout(hbox)
+
         self.buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         vbox.addWidget(self.buttonbox)
         self.buttonbox.accepted.connect(self.accept)
@@ -70,3 +75,6 @@ class XDFStreamsDialog(QDialog):
     @property
     def prefix_markers(self):
         return self._prefix_markers.isChecked()
+
+    def details(self):
+        self.parent().xdf_meta_info(self.fname)

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -457,7 +457,13 @@ class MainWindow(QMainWindow):
                     selected = enabled[0]
                 else:
                     selected = None
-                dialog = XDFStreamsDialog(self, rows, selected=selected, disabled=disabled)
+                dialog = XDFStreamsDialog(
+                    self,
+                    rows,
+                    fname=fname,
+                    selected=selected,
+                    disabled=disabled,
+                )
                 if dialog.exec():
                     row = dialog.view.selectionModel().selectedRows()[0].row()
                     stream_id = dialog.model.data(dialog.model.index(row, 0))
@@ -528,7 +534,9 @@ class MainWindow(QMainWindow):
 
     def xdf_meta_info(self, fname=None):
         """Show XDF meta info."""
-        xml = get_xml(self.model.current["fname"])
+        if fname is None:
+            fname = self.model.current["fname"]
+        xml = get_xml(fname)
         dialog = MetaInfoDialog(self, xml)
         dialog.exec()
 

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -96,10 +96,6 @@ class MainWindow(QMainWindow):
                                                          QKeySequence.Close)
         self.actions["close_all"] = file_menu.addAction("Close all", self.close_all)
         file_menu.addSeparator()
-        icon = QIcon.fromTheme("meta-info")
-        self.actions["meta_info"] = file_menu.addAction(icon, "Show information...",
-                                                        self.meta_info)
-        file_menu.addSeparator()
         self.actions["import_bads"] = file_menu.addAction(
             "Import bad channels...",
             lambda: self.import_file(model.import_bads, "Import bad channels", "*.csv")
@@ -143,6 +139,11 @@ class MainWindow(QMainWindow):
             lambda: self.export_file(model.export_ica, "Export ICA", "*.fif *.fif.gz")
         )
         file_menu.addSeparator()
+        icon = QIcon.fromTheme("meta-info")
+        self.actions["xdf_meta_info"] = file_menu.addAction(
+            "Show XDF meta information",
+            self.xdf_meta_info,
+        )
         self.actions["xdf_chunks"] = file_menu.addAction("Show XDF chunks...",
                                                          self.xdf_chunks)
         file_menu.addSeparator()
@@ -244,7 +245,6 @@ class MainWindow(QMainWindow):
         self.toolbar = self.addToolBar("toolbar")
         self.toolbar.setObjectName("toolbar")
         self.toolbar.addAction(self.actions["open_file"])
-        self.toolbar.addAction(self.actions["meta_info"])
         self.toolbar.addSeparator()
         self.toolbar.addAction(self.actions["chan_props"])
         self.toolbar.addSeparator()
@@ -402,7 +402,7 @@ class MainWindow(QMainWindow):
             self.actions["append_data"].setEnabled(
                 enabled and append and (self.model.current["dtype"] in ("raw", "epochs"))
             )
-            self.actions["meta_info"].setEnabled(
+            self.actions["xdf_meta_info"].setEnabled(
                 enabled and self.model.current["ftype"] in ["XDF", "XDFZ", "XDF.GZ"]
             )
             self.actions["convert_od"].setEnabled(
@@ -526,7 +526,7 @@ class MainWindow(QMainWindow):
             while len(self.model) > 0:
                 self.model.remove_data()
 
-    def meta_info(self):
+    def xdf_meta_info(self, fname=None):
         """Show XDF meta info."""
         xml = get_xml(self.model.current["fname"])
         dialog = MetaInfoDialog(self, xml)


### PR DESCRIPTION
- As the "Show information..." button is only applicable to XDF files, it is moved to the file menu and renamed to "Show XDF meta information". 
- In the XDF stream selection dialog, a "Details..." button is added which also opens the meta info window.
