### PR TITLE
Show exceptions in an error message box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add support to select and load multiple files at once ([#257](https://github.com/cbrnr/mnelab/pull/257) by [Florian Hofer](https://github.com/hofaflo))
 - Add drag and drop reordering to sidebar ([#261](https://github.com/cbrnr/mnelab/pull/261) by [Florian Hofer](https://github.com/hofaflo))
 - Add support for plotting evoked potentials averaged over channels (Plot -> Evoked comparison...) ([#256](https://github.com/cbrnr/mnelab/pull/256) by [Florian Hofer](https://github.com/hofaflo))
+- Exceptions are now shown in an error message box instead of being silently caught ([#268](https://github.com/cbrnr/mnelab/pull/268) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -3,6 +3,7 @@
 # License: BSD (3-clause)
 
 import multiprocessing as mp
+import sys
 import traceback
 from functools import partial
 from pathlib import Path
@@ -66,6 +67,7 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.model = model  # data model
         self.setWindowTitle("MNELAB")
+        sys.excepthook = self._excepthook
 
         # restore settings
         settings = read_settings()
@@ -298,6 +300,11 @@ class MainWindow(QMainWindow):
 
         self.setAcceptDrops(True)
         self.data_changed()
+
+    def _excepthook(self, type, value, traceback_):
+        exception_text = str(value)
+        traceback_text = "".join(traceback.format_exception(type, value, traceback_))
+        ErrorMessageBox(self, exception_text, "", traceback_text).show()
 
     def _sidebar_edit_event(self, edit):
         """


### PR DESCRIPTION
As an example, trying to set a montage with channels not in the chosen configuration leads to this ("Show Details..." shows the full traceback):
![image](https://user-images.githubusercontent.com/22592497/153279809-dbff6976-3a26-4ded-8b39-7a70945e763c.png)