### PR TITLE
Use short names in sidebar, absolute paths in infowidget

### DIFF
--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -51,7 +51,7 @@ def split_name_ext(fname):
     for i in range(-maxsuffixes, 0):
         ext = "".join(suffixes[i:]).lower()
         if ext in readers.keys():
-            return fname[:-len(ext)], ext
+            return Path(fname).name[:-len(ext)], ext
 
 
 def read_raw(fname, *args, **kwargs):

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -6,6 +6,7 @@ from collections import Counter, defaultdict
 from copy import deepcopy
 from functools import wraps
 from os.path import getsize, join, split, splitext
+from pathlib import Path
 
 import mne
 import numpy as np
@@ -104,6 +105,7 @@ class Model:
     @data_changed
     def load(self, fname, *args, **kwargs):
         """Load data set from file."""
+        fname = str(Path(fname).resolve())
         data = read_raw(fname, *args, **kwargs, preload=True)
         argstr = ", " + f"{', '.join(f'{v}' for v in args)}" if args else ""
         if kwargs:


### PR DESCRIPTION
Resolves #260 

Example screenshot:
![image](https://user-images.githubusercontent.com/22592497/153307534-42cdb696-7da3-44f6-b5fb-6282cce224dc.png)

This also ensures absolute paths are shown in the infowidget for files loaded via commandline arguments.