### PR TITLE
Print caught exceptions to stderr

### DIFF
--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -304,6 +304,7 @@ class MainWindow(QMainWindow):
     def _excepthook(self, type, value, traceback_):
         exception_text = str(value)
         traceback_text = "".join(traceback.format_exception(type, value, traceback_))
+        print(traceback_text, file=sys.stderr)
         ErrorMessageBox(self, exception_text, "", traceback_text).show()
 
     def _sidebar_edit_event(self, edit):


### PR DESCRIPTION
If something crashes before the application is able to show the error message box introduced in #268, there's no error message at all. While this should hopefully only happen to developers, it's helpful if all exceptions are also sent to stderr 😅 