### PR TITLE
Add isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
   rev: 3.9.2
   hooks:
   - id: flake8
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort

--- a/mnelab/__main__.py
+++ b/mnelab/__main__.py
@@ -4,6 +4,5 @@
 
 from . import main
 
-
 if __name__ == "__main__":
     main()

--- a/mnelab/dialogs/annotations.py
+++ b/mnelab/dialogs/annotations.py
@@ -3,8 +3,16 @@
 # License: BSD (3-clause)
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import (QAbstractItemView, QDialog, QDialogButtonBox, QHBoxLayout,
-                               QPushButton, QTableWidget, QTableWidgetItem, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
 
 from .events import IntTableWidgetItem
 

--- a/mnelab/dialogs/append.py
+++ b/mnelab/dialogs/append.py
@@ -3,8 +3,16 @@
 # License: BSD (3-clause)
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import (QAbstractItemView, QDialog, QDialogButtonBox, QGridLayout,
-                               QLabel, QListWidget, QPushButton, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QListWidget,
+    QPushButton,
+    QVBoxLayout,
+)
 
 
 class AppendDialog(QDialog):

--- a/mnelab/dialogs/channel_properties.py
+++ b/mnelab/dialogs/channel_properties.py
@@ -5,8 +5,15 @@
 from mne.io.pick import channel_type, get_channel_type_constants
 from PySide6.QtCore import QSortFilterProxyModel, Qt, Slot
 from PySide6.QtGui import QStandardItem, QStandardItemModel
-from PySide6.QtWidgets import (QAbstractItemView, QComboBox, QDialog, QDialogButtonBox,
-                               QStyledItemDelegate, QTableView, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QStyledItemDelegate,
+    QTableView,
+    QVBoxLayout,
+)
 
 channel_types = [k.upper() for k in get_channel_type_constants().keys()]
 

--- a/mnelab/dialogs/crop.py
+++ b/mnelab/dialogs/crop.py
@@ -3,8 +3,14 @@
 # License: BSD (3-clause)
 
 from PySide6.QtCore import Slot
-from PySide6.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QDoubleSpinBox,
-                               QGridLayout, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QGridLayout,
+    QVBoxLayout,
+)
 
 
 class CropDialog(QDialog):

--- a/mnelab/dialogs/epoch.py
+++ b/mnelab/dialogs/epoch.py
@@ -4,8 +4,15 @@
 
 from numpy import unique
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QDoubleSpinBox,
-                               QGridLayout, QLabel, QListWidget)
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QGridLayout,
+    QLabel,
+    QListWidget,
+)
 
 
 class EpochDialog(QDialog):

--- a/mnelab/dialogs/erds.py
+++ b/mnelab/dialogs/erds.py
@@ -2,8 +2,14 @@
 #
 # License: BSD (3-clause)
 
-from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QDoubleSpinBox, QGridLayout,
-                               QLabel, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QGridLayout,
+    QLabel,
+    QVBoxLayout,
+)
 
 
 class ERDSDialog(QDialog):

--- a/mnelab/dialogs/events.py
+++ b/mnelab/dialogs/events.py
@@ -3,8 +3,16 @@
 # License: BSD (3-clause)
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import (QAbstractItemView, QDialog, QDialogButtonBox, QHBoxLayout,
-                               QPushButton, QTableWidget, QTableWidgetItem, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
 
 
 class IntTableWidgetItem(QTableWidgetItem):

--- a/mnelab/dialogs/filter.py
+++ b/mnelab/dialogs/filter.py
@@ -2,8 +2,14 @@
 #
 # License: BSD (3-clause)
 
-from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QGridLayout, QLabel, QLineEdit,
-                               QVBoxLayout)
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+)
 
 
 class FilterDialog(QDialog):

--- a/mnelab/dialogs/find_events.py
+++ b/mnelab/dialogs/find_events.py
@@ -2,8 +2,16 @@
 #
 # License: BSD (3-clause)
 
-from PySide6.QtWidgets import (QCheckBox, QComboBox, QDialog, QDialogButtonBox, QGridLayout,
-                               QLabel, QSpinBox, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QSpinBox,
+    QVBoxLayout,
+)
 
 MAX_INT = 2147483647
 

--- a/mnelab/dialogs/history.py
+++ b/mnelab/dialogs/history.py
@@ -3,8 +3,13 @@
 # License: BSD (3-clause)
 
 from PySide6.QtGui import QFont, QGuiApplication
-from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QPlainTextEdit, QPushButton,
-                               QVBoxLayout)
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+)
 
 from ..utils import PythonHighlighter
 

--- a/mnelab/dialogs/interpolate_bads.py
+++ b/mnelab/dialogs/interpolate_bads.py
@@ -2,9 +2,17 @@
 #
 # License: BSD (3-clause)
 
-from PySide6.QtWidgets import (QCheckBox, QComboBox, QDialog, QDialogButtonBox,
-                               QDoubleSpinBox, QGridLayout, QHBoxLayout, QLabel,
-                               QVBoxLayout)
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+)
 
 
 class InterpolateBadsDialog(QDialog):

--- a/mnelab/dialogs/meta_info.py
+++ b/mnelab/dialogs/meta_info.py
@@ -4,8 +4,13 @@
 
 import xml.etree.ElementTree as ETree
 
-from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QTreeWidget, QTreeWidgetItem,
-                               QVBoxLayout)
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+)
 
 
 def populate_tree(parent, node):

--- a/mnelab/dialogs/montage.py
+++ b/mnelab/dialogs/montage.py
@@ -4,8 +4,14 @@
 
 from mne.channels import make_standard_montage
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QHBoxLayout, QListWidget,
-                               QPushButton, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QListWidget,
+    QPushButton,
+    QVBoxLayout,
+)
 
 
 class MontageDialog(QDialog):

--- a/mnelab/dialogs/plot_evoked.py
+++ b/mnelab/dialogs/plot_evoked.py
@@ -3,8 +3,15 @@
 # License: BSD (3-clause)
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import (QCheckBox, QComboBox, QDialog, QDialogButtonBox,
-                               QGridLayout, QLabel, QListWidget)
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QListWidget,
+)
 
 
 def select_all(list_widget):

--- a/mnelab/dialogs/reference.py
+++ b/mnelab/dialogs/reference.py
@@ -3,9 +3,17 @@
 # License: BSD (3-clause)
 
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QGridLayout,
-                               QGroupBox, QLabel, QLineEdit, QListWidget,
-                               QRadioButton, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QRadioButton,
+    QVBoxLayout,
+)
 
 
 class ReferenceDialog(QDialog):

--- a/mnelab/dialogs/run_ica.py
+++ b/mnelab/dialogs/run_ica.py
@@ -3,8 +3,16 @@
 # License: BSD (3-clause)
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import (QCheckBox, QComboBox, QDialog, QDialogButtonBox, QGridLayout,
-                               QLabel, QSpinBox, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QSpinBox,
+    QVBoxLayout,
+)
 
 
 class RunICADialog(QDialog):

--- a/mnelab/dialogs/xdf_chunks.py
+++ b/mnelab/dialogs/xdf_chunks.py
@@ -4,8 +4,15 @@
 
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtGui import QFont, QStandardItem, QStandardItemModel
-from PySide6.QtWidgets import (QAbstractItemView, QDialog, QDialogButtonBox, QHBoxLayout,
-                               QPlainTextEdit, QTableView, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QPlainTextEdit,
+    QTableView,
+    QVBoxLayout,
+)
 
 
 def _add_item(item):

--- a/mnelab/dialogs/xdf_streams.py
+++ b/mnelab/dialogs/xdf_streams.py
@@ -4,8 +4,16 @@
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItem, QStandardItemModel
-from PySide6.QtWidgets import (QAbstractItemView, QCheckBox, QDialog, QDialogButtonBox,
-                               QHBoxLayout, QTableView, QVBoxLayout, QPushButton)
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QPushButton,
+    QTableView,
+    QVBoxLayout,
+)
 
 
 class XDFStreamsDialog(QDialog):

--- a/mnelab/io/xdf.py
+++ b/mnelab/io/xdf.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import mne
 import numpy as np
 from pyxdf import load_xdf, match_streaminfos, resolve_streams
-from pyxdf.pyxdf import open_xdf, _read_varlen_int
+from pyxdf.pyxdf import _read_varlen_int, open_xdf
 
 
 def read_raw_xdf(fname, stream_id, srate="effective", prefix_markers=False, *args,

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -12,11 +12,28 @@ from sys import version_info
 import mne
 import numpy as np
 from mne.io.pick import channel_type
-from PySide6.QtCore import (QEvent, QMetaObject, QModelIndex, QObject, QPoint, QSettings,
-                            QSize, Qt, Slot)
+from PySide6.QtCore import (
+    QEvent,
+    QMetaObject,
+    QModelIndex,
+    QObject,
+    QPoint,
+    QSettings,
+    QSize,
+    Qt,
+    Slot,
+)
 from PySide6.QtGui import QAction, QDropEvent, QIcon, QKeySequence
-from PySide6.QtWidgets import (QApplication, QFileDialog, QFrame, QLabel,
-                               QMainWindow, QMessageBox, QSplitter, QListWidget)
+from PySide6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QFrame,
+    QLabel,
+    QListWidget,
+    QMainWindow,
+    QMessageBox,
+    QSplitter,
+)
 from pyxdf import resolve_streams
 
 from .dialogs import *  # noqa: F403

--- a/mnelab/test/test_readers.py
+++ b/mnelab/test/test_readers.py
@@ -1,4 +1,5 @@
 import pytest
+
 from mnelab.io.readers import split_name_ext, supported
 
 

--- a/mnelab/viz.py
+++ b/mnelab/viz.py
@@ -6,8 +6,8 @@ import math
 
 import matplotlib.pyplot as plt
 from mne.time_frequency import tfr_multitaper
-from mne.viz.utils import center_cmap
 from mne.viz import plot_compare_evokeds
+from mne.viz.utils import center_cmap
 
 
 def _get_rows_cols(n):

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,3 +45,8 @@ max-line-length = 92
 per-file-ignores =
     __init__.py:F401
     mainwindow.py:F405
+
+[isort]
+line_length = 92
+multi_line_output = 3
+include_trailing_comma = true


### PR DESCRIPTION
I initially just wanted to add an `isort` key in `setup.cfg` to avoid defining the value in the VSCode settings, then figured we might as well ensure it in pre-commit. Of course this comes with cleaning up all imports at once to make the style checks green 😅 