### PR TITLE
Fix exporting BAD and EDGE annotations to BV

### DIFF
--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -117,7 +117,7 @@ def write_bv(fname, raw, events=None):
     ch_names = raw.info["ch_names"]
     if events is None:
         if raw.annotations:
-            events = mne.events_from_annotations(raw)[0]
+            events = mne.events_from_annotations(raw, regexp=None)[0]
             dur = raw.annotations.duration * fs
             events = np.column_stack([events[:, [0, 2]], dur.astype(int)])
     else:


### PR DESCRIPTION
Fixes #104. Currently, `pybv` doesn't write suitable marker types, but it's better than not working at all for now.