### PR TITLE
Add significance masks to Plot ERDS maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add a settings menu (File -> Settings...) ([#289](https://github.com/cbrnr/mnelab/pull/289) by [Florian Hofer](https://github.com/hofaflo))
 - Add ability to import events from FIF files ([#284](https://github.com/cbrnr/mnelab/pull/284) by [Florian Hofer](https://github.com/hofaflo))
 - Add support for plotting ERDS topomaps (Plot -> ERDS topomaps...) ([#278](https://github.com/cbrnr/mnelab/pull/278) by [Florian Hofer](https://github.com/hofaflo))
+- Add possibility to apply significance masks to ERDS plots ([#279](https://github.com/cbrnr/mnelab/pull/279) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))

--- a/mnelab/dialogs/calc.py
+++ b/mnelab/dialogs/calc.py
@@ -15,3 +15,4 @@ class CalcDialog(QDialog):
         button.rejected.connect(self.close)
         vbox.addWidget(label)
         vbox.addWidget(button)
+        self.resize(300, 100)

--- a/mnelab/dialogs/erds.py
+++ b/mnelab/dialogs/erds.py
@@ -7,8 +7,10 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QDoubleSpinBox,
     QGridLayout,
+    QGroupBox,
     QLabel,
     QListWidget,
+    QLineEdit,
     QVBoxLayout,
 )
 
@@ -79,6 +81,19 @@ class ERDSDialog(QDialog):
         self._b2.setSingleStep(0.1)
         self._b2.setSuffix(" s")
         grid.addWidget(self._b2, 3, 2)
+
+        self.significance_mask = QGroupBox("Significance mask")
+        self.significance_mask.setCheckable(True)
+        self.significance_mask.setChecked(False)
+        significance_mask_grid = QGridLayout()
+        significance_mask_grid.setColumnStretch(0, 2)
+        significance_mask_grid.setColumnStretch(1, 3)
+        significance_mask_grid.addWidget(QLabel("alpha:"), 0, 0)
+        self.alpha = QLineEdit()
+        self.alpha.setText("0.05")
+        significance_mask_grid.addWidget(self.alpha, 0, 1)
+        self.significance_mask.setLayout(significance_mask_grid)
+        grid.addWidget(self.significance_mask, 4, 0, 1, 3)
 
         vbox.addLayout(grid)
         buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)

--- a/mnelab/dialogs/erds.py
+++ b/mnelab/dialogs/erds.py
@@ -86,7 +86,7 @@ class ERDSDialog(QDialog):
         self.alpha = QDoubleSpinBox()
         self.alpha.setMinimum(0)
         self.alpha.setValue(0.05)
-        self.alpha.setDecimals(3)
+        self.alpha.setDecimals(2)
         self.alpha.setSingleStep(0.01)
         grid.addWidget(self.significance_mask, 4, 0)
         grid.addWidget(self.alpha, 4, 1)

--- a/mnelab/dialogs/erds.py
+++ b/mnelab/dialogs/erds.py
@@ -3,14 +3,13 @@
 # License: BSD (3-clause)
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtWidgets import (
+    QCheckBox,
     QDialog,
     QDialogButtonBox,
     QDoubleSpinBox,
     QGridLayout,
-    QGroupBox,
     QLabel,
     QListWidget,
-    QLineEdit,
     QVBoxLayout,
 )
 
@@ -82,18 +81,17 @@ class ERDSDialog(QDialog):
         self._b2.setSuffix(" s")
         grid.addWidget(self._b2, 3, 2)
 
-        self.significance_mask = QGroupBox("Significance mask")
-        self.significance_mask.setCheckable(True)
+        self.significance_mask = QCheckBox("Significance level:")
         self.significance_mask.setChecked(False)
-        significance_mask_grid = QGridLayout()
-        significance_mask_grid.setColumnStretch(0, 2)
-        significance_mask_grid.setColumnStretch(1, 3)
-        significance_mask_grid.addWidget(QLabel("alpha:"), 0, 0)
-        self.alpha = QLineEdit()
-        self.alpha.setText("0.05")
-        significance_mask_grid.addWidget(self.alpha, 0, 1)
-        self.significance_mask.setLayout(significance_mask_grid)
-        grid.addWidget(self.significance_mask, 4, 0, 1, 3)
+        self.alpha = QDoubleSpinBox()
+        self.alpha.setMinimum(0)
+        self.alpha.setValue(0.05)
+        self.alpha.setDecimals(3)
+        self.alpha.setSingleStep(0.01)
+        grid.addWidget(self.significance_mask, 4, 0)
+        grid.addWidget(self.alpha, 4, 1)
+        self.significance_mask.toggled.connect(self.toggle_alpha)
+        self.toggle_alpha()
 
         vbox.addLayout(grid)
         buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -129,6 +127,10 @@ class ERDSDialog(QDialog):
     @property
     def b2(self):
         return self._b2.value()
+
+    @Slot()
+    def toggle_alpha(self):
+        self.alpha.setEnabled(self.significance_mask.isChecked())
 
 
 class ERDSTopomapsDialog(QDialog):

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -33,7 +33,7 @@ from .model import InvalidAnnotationsError, LabelsNotFoundError, Model
 from .settings import SettingsDialog, read_settings, write_settings
 from .utils import count_locations, have, image_path, interface_style, natural_sort
 from .viz import (
-    calc_tfr_and_masks,
+    _calc_tfr,
     plot_erds,
     plot_erds_topomaps,
     plot_evoked,
@@ -778,7 +778,7 @@ class MainWindow(QMainWindow):
 
             pool = mp.Pool(processes=1)
             res = pool.apply_async(
-                func=calc_tfr_and_masks,
+                func=_calc_tfr,
                 args=(data, freqs, baseline, times, alpha),
                 callback=callback
             )

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -765,7 +765,7 @@ class MainWindow(QMainWindow):
             times = [dialog.t1, dialog.t2]
             alpha = None
             if dialog.significance_mask.isChecked():
-                alpha = float(dialog.alpha.text())
+                alpha = dialog.alpha.value()
 
             calc = CalcDialog(
                 self,

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -786,7 +786,6 @@ class MainWindow(QMainWindow):
 
             if not calc.exec():
                 pool.terminate()
-                res.get()
                 print("ERDS map calculation aborted.")
             else:
                 tfr_and_masks = res.get(timeout=1)

--- a/mnelab/viz.py
+++ b/mnelab/viz.py
@@ -152,7 +152,7 @@ def plot_erds(tfr_and_masks):
         widths = n_cols * [10] + [1]  # each map has width 10, each colorbar width 1
         fig, axes = plt.subplots(n_rows, n_cols + 1, gridspec_kw={"width_ratios": widths})
         vmin, vmax = -1, 2  # default for ERDS maps
-        cmap = center_cmap(plt.cm.RdBu, vmin, vmax)
+        cmap = _center_cmap(plt.cm.RdBu, vmin, vmax)
 
         # skip the last column in `axes`, as it contains the colorbar
         for (ch_name, mask), ax in zip(masks.items(), axes[..., :-1].flat):

--- a/mnelab/viz.py
+++ b/mnelab/viz.py
@@ -6,6 +6,7 @@ import math
 
 import matplotlib.pyplot as plt
 import numpy as np
+from mne.stats import permutation_cluster_1samp_test as pcluster_test
 from mne.time_frequency import tfr_multitaper
 from mne.viz import plot_compare_evokeds
 
@@ -68,30 +69,110 @@ def _get_rows_cols(n):
     return rows, cols
 
 
-def plot_erds(data, freqs, n_cycles, baseline, times=(None, None)):
-    tfr = tfr_multitaper(data, freqs, n_cycles, average=False, return_itc=False)
+def calc_tfr_and_masks(epochs, freqs, baseline, times, alpha=None):
+    """
+    Calculate AverageTFR and significance masks for given epochs.
+
+    Adapted from https://mne.tools/dev/auto_examples/time_frequency/time_frequency_erds.html
+
+    Parameters
+    ----------
+    epochs : mne.epochs.Epochs
+        Epochs extracted from a Raw instance.
+    freqs : np.ndarray
+        The frequencies in Hz.
+    baseline : array_like, shape (2,)
+        The time interval to apply rescaling / baseline correction.
+    times : array_like, shape (2,)
+        Start and end of crop time interval.
+    alpha : float, optional
+        If specified, calculate significance maps with threshold `alpha`, by default `None`.
+
+    Returns
+    -------
+    dict[str, tuple[mne.time_frequency.tfr.EpochsTFR, dict[str, np.ndarray | None]]]
+        A dictionary where keys are event IDs and values are tuples (`tfr_ev`, `masks`).
+        `tfr_ev` is the EpochsTFR object for the respective event. `masks` is again a
+        dictionary, where keys are channel names and values are significance masks.
+        Significance masks are `None` if `alpha` was not specified.
+    """
+    tfr = tfr_multitaper(epochs, freqs, freqs, average=False, return_itc=False)
     tfr.apply_baseline(baseline, mode="percent")
     tfr.crop(*times)
 
-    figs = []
-    n_rows, n_cols = _get_rows_cols(data.info["nchan"])
-    widths = n_cols * [10] + [1]  # each map has width 10, each colorbar width 1
+    pcluster_kwargs = dict(
+        n_permutations=100,
+        step_down_p=0.05,
+        seed=1,
+        buffer_size=None,
+        out_type='mask',
+    )
 
-    for event in data.event_id:  # separate figures for each event ID
+    res = {}
+
+    for event in epochs.event_id:
+        tfr_ev = tfr[event]
+        masks = {}
+        for ch in range(epochs.info["nchan"]):
+            mask = None
+            if alpha is not None:
+                # positive clusters
+                _, c1, p1, _ = pcluster_test(tfr_ev.data[:, ch], tail=1, **pcluster_kwargs)
+                # negative clusters
+                _, c2, p2, _ = pcluster_test(tfr_ev.data[:, ch], tail=-1, **pcluster_kwargs)
+
+                c = np.stack(c1 + c2, axis=2)  # combined clusters
+                p = np.concatenate((p1, p2))   # combined p-values
+                mask = c[..., p <= alpha].any(axis=-1)
+            masks[epochs.ch_names[ch]] = mask
+        res[event] = (tfr_ev, masks)
+    return res
+
+
+def plot_erds(tfr_and_masks):
+    """
+    Plot ERDS maps from given TFR and significance masks.
+
+    Parameters
+    ----------
+    tfr_and_masks : dict[str, tuple[EpochsTFR, dict[str, np.ndarray |None]]]
+        A dictionary where keys are event IDs and values are tuples (`tfr_ev`, `masks`).
+        `tfr_ev` is the EpochsTFR object for the respective event. `masks` is again a
+        dictionary, where keys are channel names and values are significance masks.
+
+    Returns
+    -------
+    list[matplotlib.figure.Figure]
+        A list of the figure(s) generated, one figure per event.
+    """
+    figs = []
+
+    for event, (tfr_ev, masks) in tfr_and_masks.items():
+        n_rows, n_cols = _get_rows_cols(tfr_ev.info["nchan"])
+        widths = n_cols * [10] + [1]  # each map has width 10, each colorbar width 1
         fig, axes = plt.subplots(n_rows, n_cols + 1, gridspec_kw={"width_ratios": widths})
-        tfr_avg = tfr[event].average()
         vmin, vmax = -1, 2  # default for ERDS maps
-        cmap = _center_cmap(plt.cm.RdBu, vmin, vmax)
-        for ch, ax in enumerate(axes[..., :-1].flat):  # skip last column
-            tfr_avg.plot([ch], vmin=vmin, vmax=vmax, cmap=(cmap, False), axes=ax,
-                         colorbar=False, show=False)
-            ax.set_title(data.ch_names[ch], fontsize=10)
+        cmap = center_cmap(plt.cm.RdBu, vmin, vmax)
+
+        # skip the last column in `axes`, as it contains the colorbar
+        for (ch_name, mask), ax in zip(masks.items(), axes[..., :-1].flat):
+            tfr_ev.average().plot(
+                [ch_name],
+                vmin=vmin,
+                vmax=vmax,
+                cmap=(cmap, False),
+                axes=ax,
+                colorbar=False,
+                mask=mask,
+                mask_style="mask" if mask is not None else None,  # avoid RuntimeWarning
+                show=False,
+            )
+            ax.set_title(ch_name, fontsize=10)
             ax.axvline(0, linewidth=1, color="black", linestyle=":")
             ax.set(xlabel="t (s)", ylabel="f (Hz)")
             ax.label_outer()
-        for ax in axes[..., -1].flat:  # colorbars in last column
+        for ax in axes[..., -1].flat:
             fig.colorbar(axes.flat[0].images[-1], cax=ax)
-
         fig.suptitle(f"ERDS ({event})")
         figs.append(fig)
     return figs

--- a/mnelab/viz.py
+++ b/mnelab/viz.py
@@ -69,7 +69,7 @@ def _get_rows_cols(n):
     return rows, cols
 
 
-def calc_tfr_and_masks(epochs, freqs, baseline, times, alpha=None):
+def _calc_tfr(epochs, freqs, baseline, times, alpha=None):
     """
     Calculate AverageTFR and significance masks for given epochs.
 


### PR DESCRIPTION
To allow cancelling the significance mask calculation, this required more changes than expected...
The figures created by [`AverageTFR.plot`](https://mne.tools/stable/generated/mne.time_frequency.AverageTFR.html#mne.time_frequency.AverageTFR.plot) can't be pickled (and thus not passed between processes), so we can't just extend the existing `mnelab.viz.plot_erds` with significance masks and call it like it's done for ICA calculation. I've created a new function `calc_tfr_and_masks` which just calculates the tfr and significance masks in a new process. After that, `plot_erds` takes the return of `calc_tfr_and_masks` to create the figures.
Naming and data structure are of course up for discussion 😅 