### PR TITLE
Add ability to pick channels by channel type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Move "Show information..." from toolbar to "File" menu and rename to "Show XDF meta information" ([#266](https://github.com/cbrnr/mnelab/pull/266) by [Florian Hofer](https://github.com/hofaflo))
 - Replace `utils.has_location` with `utils.count_locations`, which returns the number of locations instead of a boolean ([#271](https://github.com/cbrnr/mnelab/pull/271) by [Florian Hofer](https://github.com/hofaflo))
 - Stop requiring existing annotations or events to enable editing them ([#283](https://github.com/cbrnr/mnelab/pull/283) by [Florian Hofer](https://github.com/hofaflo))
+- Replace "(channels dropped)" suffix with "(channels picked)" and use `pick_channels` instead of `drop_channels` ([#285](https://github.com/cbrnr/mnelab/pull/285) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Add support for plotting topomaps of evoked potentials (Plot -> Evoked topomaps...) ([#277](https://github.com/cbrnr/mnelab/pull/277) by [Florian Hofer](https://github.com/hofaflo))
 - Add montage name and location count to infowidget ([#271](https://github.com/cbrnr/mnelab/pull/271) by [Florian Hofer](https://github.com/hofaflo))
 - Add possibility to specify `match_case`, `match_alias`, and `on_missing` to "Set montage..." ([#271](https://github.com/cbrnr/mnelab/pull/271) by [Florian Hofer](https://github.com/hofaflo))
-- Add "Clear montage" to "Edit" menu  ([#271](https://github.com/cbrnr/mnelab/pull/271) by [Florian Hofer](https://github.com/hofaflo))
+- Add "Clear montage" to "Edit" menu ([#271](https://github.com/cbrnr/mnelab/pull/271) by [Florian Hofer](https://github.com/hofaflo))
+- Add ability to pick channels by channel type ([#285](https://github.com/cbrnr/mnelab/pull/285) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))

--- a/mnelab/dialogs/pick_channels.py
+++ b/mnelab/dialogs/pick_channels.py
@@ -2,38 +2,65 @@
 #
 # License: BSD (3-clause)
 
-from PySide6.QtCore import Slot
-from PySide6.QtWidgets import QDialog, QDialogButtonBox, QListWidget, QVBoxLayout
+from PySide6.QtCore import Qt, Slot
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QListWidget,
+    QRadioButton,
+)
+
+from .utils import select_all
 
 
 class PickChannelsDialog(QDialog):
-    def __init__(self, parent, channels, selected=None, title="Pick channels"):
+    def __init__(self, parent, channels, types):
         super().__init__(parent)
-        self.setWindowTitle(title)
-        if selected is None:
-            selected = []
-        self.initial_selection = selected
-        vbox = QVBoxLayout(self)
-        self.channels = QListWidget()
-        self.channels.insertItems(0, channels)
-        self.channels.setSelectionMode(QListWidget.ExtendedSelection)
-        for i in range(self.channels.count()):
-            if self.channels.item(i).data(0) in selected:
-                self.channels.item(i).setSelected(True)
-        vbox.addWidget(self.channels)
+        self.setWindowTitle("Pick channels")
+
+        grid = QGridLayout(self)
+
+        self.by_name = QRadioButton("By name:")
+        grid.addWidget(self.by_name, 0, 0, Qt.AlignTop)
+        self.names = QListWidget()
+        self.names.insertItems(0, channels)
+        self.names.setSelectionMode(QListWidget.ExtendedSelection)
+        select_all(self.names)
+        grid.addWidget(self.names, 0, 1)
+        self.by_name.setChecked(True)
+
+        self.by_type = QRadioButton("By type:")
+        grid.addWidget(self.by_type, 1, 0, Qt.AlignTop)
+        self.types = QListWidget()
+        self.types.insertItems(0, types)
+        self.types.setSelectionMode(QListWidget.ExtendedSelection)
+        self.types.setMaximumHeight(self.types.sizeHintForRow(0) * 5.5)
+        select_all(self.types)
+        grid.addWidget(self.types, 1, 1)
+
         self.buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        vbox.addWidget(self.buttonbox)
+        grid.addWidget(self.buttonbox, 2, 0, 1, -1)
         self.buttonbox.accepted.connect(self.accept)
         self.buttonbox.rejected.connect(self.reject)
-        self.channels.itemSelectionChanged.connect(self.toggle_buttons)
+        self.types.itemSelectionChanged.connect(self.toggle_buttons)
+        self.names.itemSelectionChanged.connect(self.toggle_buttons)
+        self.by_name.toggled.connect(self.toggle_buttons)
         self.toggle_buttons()  # initialize OK button state
+
+        self.by_name.toggled.connect(self.toggle_lists)
+        self.by_type.toggled.connect(self.toggle_lists)
+        self.toggle_lists()
 
     @Slot()
     def toggle_buttons(self):
-        """Toggle OK button.
-        """
-        selected = [item.data(0) for item in self.channels.selectedItems()]
-        if selected != self.initial_selection:
+        """Toggle OK button."""
+        self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(False)
+        if (self.by_name.isChecked() and self.names.selectedItems()
+                or self.by_type.isChecked() and self.types.selectedItems()):
             self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(True)
-        else:
-            self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(False)
+
+    @Slot()
+    def toggle_lists(self):
+        self.names.setEnabled(self.by_name.isChecked())
+        self.types.setEnabled(not self.by_name.isChecked())

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -595,14 +595,21 @@ class MainWindow(QMainWindow):
     def pick_channels(self):
         """Pick channels in current data set."""
         channels = self.model.current["data"].info["ch_names"]
-        dialog = PickChannelsDialog(self, channels, selected=channels)
+        types = sorted(set(self.model.current["data"].get_channel_types()))
+        dialog = PickChannelsDialog(self, channels, types)
         if dialog.exec():
-            picks = [item.data(0) for item in dialog.channels.selectedItems()]
-            drops = list(set(channels) - set(picks))
-            if drops:
-                self.auto_duplicate()
-                self.model.drop_channels(drops)
-                self.model.history.append(f"data.drop_channels({drops})")
+            if dialog.by_name.isChecked():
+                picks = [item.text() for item in dialog.names.selectedItems()]
+                drops = list(set(channels) - set(picks))
+                if drops:
+                    self.auto_duplicate()
+                    self.model.drop_channels(drops)
+                    self.model.history.append(f"data.drop_channels({drops})")
+            else:  # by type
+                picks = [item.text() for item in dialog.types.selectedItems()]
+                if set(types) - set(picks):
+                    self.auto_duplicate()
+                    self.model.pick_channels(picks)
 
     def channel_properties(self):
         """Show channel properties dialog."""

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -600,16 +600,14 @@ class MainWindow(QMainWindow):
         if dialog.exec():
             if dialog.by_name.isChecked():
                 picks = [item.text() for item in dialog.names.selectedItems()]
-                drops = list(set(channels) - set(picks))
-                if drops:
-                    self.auto_duplicate()
-                    self.model.drop_channels(drops)
-                    self.model.history.append(f"data.drop_channels({drops})")
+                if set(channels) == set(picks):
+                    return
             else:  # by type
                 picks = [item.text() for item in dialog.types.selectedItems()]
-                if set(types) - set(picks):
-                    self.auto_duplicate()
-                    self.model.pick_channels(picks)
+                if set(types) == set(picks):
+                    return
+            self.auto_duplicate()
+            self.model.pick_channels(picks)
 
     def channel_properties(self):
         """Show channel properties dialog."""

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -355,6 +355,12 @@ class Model:
         self.current["name"] += " (channels dropped)"
 
     @data_changed
+    def pick_channels(self, picks):
+        self.current["data"] = self.current["data"].pick(picks)
+        self.current["name"] += " (channels picked)"
+        self.history.append(f"data.pick({picks})")
+
+    @data_changed
     def set_channel_properties(self, bads=None, names=None, types=None):
         if bads != self.current["data"].info["bads"]:
             self.current["data"].info["bads"] = bads

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -350,11 +350,6 @@ class Model:
                 "ICA": ica}
 
     @data_changed
-    def drop_channels(self, drops):
-        self.current["data"] = self.current["data"].drop_channels(drops)
-        self.current["name"] += " (channels dropped)"
-
-    @data_changed
     def pick_channels(self, picks):
         self.current["data"] = self.current["data"].pick(picks)
         self.current["name"] += " (channels picked)"


### PR DESCRIPTION
Example dialog:

![image](https://user-images.githubusercontent.com/22592497/153721416-80fc321c-b9f4-41b1-8883-03403f436789.png)

The existing implementation of `pick_channels` converts the "pick" to a "drop". What was the reasoning there and should it be done in this case as well?