### PR TITLE
Improve infowidget montage entry

### DIFF
--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -312,11 +312,14 @@ class Model:
         if isinstance(reference, list):
             reference = ",".join(reference)
 
-        if montage is None:
+        locations = count_locations(self.current["data"].info)
+
+        if montage is None and not locations:
             montage_text = "-"
-        else:
-            locations = count_locations(self.current["data"].info)
-            montage_text = f"{montage} ({locations}/{nchan} locations)"
+        elif montage is None and locations:
+            montage_text = f"custom ({locations}/{data.info['nchan']} locations)"
+        elif montage:
+            montage_text = f"{montage} ({locations}/{data.info['nchan']} locations)"
 
         if ica is not None:
             method = ica.method.title()

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -315,7 +315,7 @@ class Model:
         locations = count_locations(self.current["data"].info)
 
         if montage is None and not locations:
-            montage_text = "-"
+            montage_text = "none"
         elif montage is None and locations:
             montage_text = f"custom ({locations}/{data.info['nchan']} locations)"
         elif montage:


### PR DESCRIPTION
Fixes for two small issues:
- If the channel locations are included in the loaded file, the key "montage" in the data set dict is not set. As this is used to decide whether the montage details in the infowidget should be shown, they aren't.
- The `nchan` string includes "(X bad)" in case of bad channels.