### PR TITLE
Add ability to drop bad epochs

### DIFF
--- a/mnelab/dialogs/__init__.py
+++ b/mnelab/dialogs/__init__.py
@@ -7,6 +7,7 @@ from .append import AppendDialog
 from .calc import CalcDialog
 from .channel_properties import ChannelPropertiesDialog
 from .crop import CropDialog
+from .drop_bad_epochs import DropBadEpochsDialog
 from .epoch import EpochDialog
 from .erds import ERDSDialog
 from .error_message import ErrorMessageBox

--- a/mnelab/dialogs/drop_bad_epochs.py
+++ b/mnelab/dialogs/drop_bad_epochs.py
@@ -16,11 +16,14 @@ from PySide6.QtWidgets import (
 )
 
 
-def _unit(channel_type):
+def _label(channel_type):
+    label = channel_type.upper()
     try:
-        return _unit2human[get_channel_type_constants()[channel_type]["unit"]]
+        unit = _unit2human[get_channel_type_constants()[channel_type]["unit"]]
+        label += f" ({unit})"
     except KeyError:
-        return "AU"
+        pass
+    return label
 
 
 class DropBadEpochsDialog(QDialog):
@@ -36,7 +39,7 @@ class DropBadEpochsDialog(QDialog):
         self.reject_fields = {}
         reject_grid = QGridLayout()
         for row, type in enumerate(types):
-            reject_grid.addWidget(QLabel(f"{type.upper()} ({_unit(type)})"), row, 0)
+            reject_grid.addWidget(QLabel(_label(type)), row, 0)
             self.reject_fields[type] = QLineEdit()
             reject_grid.addWidget(self.reject_fields[type], row, 1)
         self.reject_box.setLayout(reject_grid)
@@ -48,7 +51,7 @@ class DropBadEpochsDialog(QDialog):
         self.flat_fields = {}
         flat_grid = QGridLayout()
         for row, type in enumerate(types):
-            flat_grid.addWidget(QLabel(f"{type.upper()} ({_unit(type)})"), row, 0)
+            flat_grid.addWidget(QLabel(_label(type)), row, 0)
             self.flat_fields[type] = QLineEdit()
             flat_grid.addWidget(self.flat_fields[type], row, 1)
         self.flat_box.setLayout(flat_grid)

--- a/mnelab/dialogs/drop_bad_epochs.py
+++ b/mnelab/dialogs/drop_bad_epochs.py
@@ -1,0 +1,60 @@
+# Copyright (c) MNELAB developers
+#
+# License: BSD (3-clause)
+
+from PySide6.QtCore import Slot
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+)
+
+
+class DropBadEpochsDialog(QDialog):
+    def __init__(self, parent, types):
+        super().__init__(parent)
+        self.setWindowTitle("Drop bad epochs")
+
+        vbox = QVBoxLayout(self)
+
+        self.reject_box = QGroupBox("Reject (maximum PTP amplitude)")
+        self.reject_box.setCheckable(True)
+        self.reject_box.setChecked(False)
+        self.reject_fields = {}
+        reject_grid = QGridLayout()
+        for row, type in enumerate(types):
+            reject_grid.addWidget(QLabel(type.upper()), row, 0)
+            self.reject_fields[type] = QLineEdit()
+            reject_grid.addWidget(self.reject_fields[type], row, 1)
+        self.reject_box.setLayout(reject_grid)
+        vbox.addWidget(self.reject_box)
+
+        self.flat_box = QGroupBox("Flat (minimum PTP amplitude)")
+        self.flat_box.setCheckable(True)
+        self.flat_box.setChecked(False)
+        self.flat_fields = {}
+        flat_grid = QGridLayout()
+        for row, type in enumerate(types):
+            flat_grid.addWidget(QLabel(type.upper()), row, 0)
+            self.flat_fields[type] = QLineEdit()
+            flat_grid.addWidget(self.flat_fields[type], row, 1)
+        self.flat_box.setLayout(flat_grid)
+        vbox.addWidget(self.flat_box)
+
+        self.buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        vbox.addWidget(self.buttonbox)
+        self.buttonbox.accepted.connect(self.accept)
+        self.buttonbox.rejected.connect(self.reject)
+        self.flat_box.toggled.connect(self.toggle_ok)
+        self.reject_box.toggled.connect(self.toggle_ok)
+        vbox.setSizeConstraint(QGridLayout.SetFixedSize)
+
+    @Slot()
+    def toggle_ok(self):
+        self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(False)
+        if self.reject_box.isChecked() or self.flat_box.isChecked():
+            self.buttonbox.button(QDialogButtonBox.Ok).setEnabled(True)

--- a/mnelab/dialogs/drop_bad_epochs.py
+++ b/mnelab/dialogs/drop_bad_epochs.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+from mne.channels.channels import _unit2human
+from mne.io.pick import get_channel_type_constants
 from PySide6.QtCore import Slot
 from PySide6.QtWidgets import (
     QDialog,
@@ -12,6 +14,13 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QVBoxLayout,
 )
+
+
+def _unit(channel_type):
+    try:
+        return _unit2human[get_channel_type_constants()[channel_type]["unit"]]
+    except KeyError:
+        return "AU"
 
 
 class DropBadEpochsDialog(QDialog):
@@ -27,7 +36,7 @@ class DropBadEpochsDialog(QDialog):
         self.reject_fields = {}
         reject_grid = QGridLayout()
         for row, type in enumerate(types):
-            reject_grid.addWidget(QLabel(type.upper()), row, 0)
+            reject_grid.addWidget(QLabel(f"{type.upper()} ({_unit(type)})"), row, 0)
             self.reject_fields[type] = QLineEdit()
             reject_grid.addWidget(self.reject_fields[type], row, 1)
         self.reject_box.setLayout(reject_grid)
@@ -39,7 +48,7 @@ class DropBadEpochsDialog(QDialog):
         self.flat_fields = {}
         flat_grid = QGridLayout()
         for row, type in enumerate(types):
-            flat_grid.addWidget(QLabel(type.upper()), row, 0)
+            flat_grid.addWidget(QLabel(f"{type.upper()} ({_unit(type)})"), row, 0)
             self.flat_fields[type] = QLineEdit()
             flat_grid.addWidget(self.flat_fields[type], row, 1)
         self.flat_box.setLayout(flat_grid)

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -497,6 +497,7 @@ class Model:
     @data_changed
     def drop_bad_epochs(self, reject, flat):
         self.current["data"].drop_bad(reject, flat)
+        self.current["name"] += " (dropped bad epochs)"
         self.history.append(f"data.drop_bad({reject}, {flat})")
 
     @data_changed

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -495,6 +495,11 @@ class Model:
         self.current["name"] += " (epoched)"
 
     @data_changed
+    def drop_bad_epochs(self, reject, flat):
+        self.current["data"].drop_bad(reject, flat)
+        self.history.append(f"data.drop_bad({reject}, {flat})")
+
+    @data_changed
     def convert_od(self):
         self.current["data"] = mne.preprocessing.nirs.optical_density(self.current["data"])
         self.current["name"] += " (OD)"


### PR DESCRIPTION
This provides an interface for [mne.Epochs.drop_bad](https://mne.tools/stable/generated/mne.Epochs.html#mne.Epochs.drop_bad).

Example dialog:
![image](https://user-images.githubusercontent.com/22592497/153724908-454c6181-6e3b-45ea-9753-6b1f236557b4.png)

Only available channel types are displayed, alternatively we could always show all but grey-out non-available ones?