### PR TITLE
Add a "Cancel" button to the overwrite dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add ability to pick channels by channel type ([#285](https://github.com/cbrnr/mnelab/pull/285) by [Florian Hofer](https://github.com/hofaflo))
 - Add a settings menu (File -> Settings...) ([#289](https://github.com/cbrnr/mnelab/pull/289) by [Florian Hofer](https://github.com/hofaflo))
 - Add ability to import events from FIF files ([#284](https://github.com/cbrnr/mnelab/pull/284) by [Florian Hofer](https://github.com/hofaflo))
+- Add a "Cancel" button to the overwrite dialog ([#293](https://github.com/cbrnr/mnelab/pull/293) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))

--- a/mnelab/dialogs/filter.py
+++ b/mnelab/dialogs/filter.py
@@ -12,8 +12,33 @@ from PySide6.QtWidgets import (
 )
 
 
-class FilterDialog(QDialog):
-    def __init__(self, parent):
+class DataSetChangeDialog(QDialog):
+    def add_buttonbox(self, force_new, vbox):
+        buttonbox = QDialogButtonBox()
+        buttonbox.addButton("Create new data set", QDialogButtonBox.YesRole)
+        overwrite_button = buttonbox.addButton(
+            "Overwrite current data set",
+            QDialogButtonBox.YesRole,
+        )
+        buttonbox.addButton("Cancel", QDialogButtonBox.RejectRole)
+
+        self.inplace = False
+        if force_new:
+            overwrite_button.setEnabled(False)
+            overwrite_button.setToolTip("Data sets with filenames are always duplicated.")
+
+        vbox.addWidget(buttonbox)
+        buttonbox.accepted.connect(self.accept)
+        buttonbox.rejected.connect(self.reject)
+        overwrite_button.clicked.connect(self.set_overwrite)
+        vbox.setSizeConstraint(QVBoxLayout.SetFixedSize)
+
+    def set_overwrite(self):
+        self.inplace = True
+
+
+class FilterDialog(DataSetChangeDialog):
+    def __init__(self, parent, force_new=False):
         super().__init__(parent)
         self.setWindowTitle("Filter data")
         vbox = QVBoxLayout(self)
@@ -25,11 +50,8 @@ class FilterDialog(QDialog):
         self.highedit = QLineEdit()
         grid.addWidget(self.highedit, 1, 1)
         vbox.addLayout(grid)
-        buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        vbox.addWidget(buttonbox)
-        buttonbox.accepted.connect(self.accept)
-        buttonbox.rejected.connect(self.reject)
-        vbox.setSizeConstraint(QVBoxLayout.SetFixedSize)
+
+        self.add_buttonbox(force_new, vbox)
 
     @property
     def low(self):

--- a/mnelab/dialogs/filter.py
+++ b/mnelab/dialogs/filter.py
@@ -12,33 +12,8 @@ from PySide6.QtWidgets import (
 )
 
 
-class DataSetChangeDialog(QDialog):
-    def add_buttonbox(self, force_new, vbox):
-        buttonbox = QDialogButtonBox()
-        buttonbox.addButton("Create new data set", QDialogButtonBox.YesRole)
-        overwrite_button = buttonbox.addButton(
-            "Overwrite current data set",
-            QDialogButtonBox.YesRole,
-        )
-        buttonbox.addButton("Cancel", QDialogButtonBox.RejectRole)
-
-        self.inplace = False
-        if force_new:
-            overwrite_button.setEnabled(False)
-            overwrite_button.setToolTip("Data sets with filenames are always duplicated.")
-
-        vbox.addWidget(buttonbox)
-        buttonbox.accepted.connect(self.accept)
-        buttonbox.rejected.connect(self.reject)
-        overwrite_button.clicked.connect(self.set_overwrite)
-        vbox.setSizeConstraint(QVBoxLayout.SetFixedSize)
-
-    def set_overwrite(self):
-        self.inplace = True
-
-
-class FilterDialog(DataSetChangeDialog):
-    def __init__(self, parent, force_new=False):
+class FilterDialog(QDialog):
+    def __init__(self, parent):
         super().__init__(parent)
         self.setWindowTitle("Filter data")
         vbox = QVBoxLayout(self)
@@ -50,8 +25,11 @@ class FilterDialog(DataSetChangeDialog):
         self.highedit = QLineEdit()
         grid.addWidget(self.highedit, 1, 1)
         vbox.addLayout(grid)
-
-        self.add_buttonbox(force_new, vbox)
+        buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        vbox.addWidget(buttonbox)
+        buttonbox.accepted.connect(self.accept)
+        buttonbox.rejected.connect(self.reject)
+        vbox.setSizeConstraint(QVBoxLayout.SetFixedSize)
 
     @property
     def low(self):

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -903,11 +903,9 @@ class MainWindow(QMainWindow):
 
     def filter_data(self):
         """Filter data."""
-        dialog = FilterDialog(self, force_new=self.model.current["fname"])
-
+        dialog = FilterDialog(self)
         if dialog.exec():
-            if not dialog.inplace:
-                self.model.duplicate_data()
+            self.auto_duplicate()
             self.model.filter(dialog.low, dialog.high)
 
     def find_events(self):

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -903,9 +903,11 @@ class MainWindow(QMainWindow):
 
     def filter_data(self):
         """Filter data."""
-        dialog = FilterDialog(self)
+        dialog = FilterDialog(self, force_new=self.model.current["fname"])
+
         if dialog.exec():
-            self.auto_duplicate()
+            if not dialog.inplace:
+                self.model.duplicate_data()
             self.model.filter(dialog.low, dialog.high)
 
     def find_events(self):


### PR DESCRIPTION
To avoid the extra dialog when modifying a data set, we could ask whether a user wants to overwrite or duplicate a data set directly in the respective action dialog:

![image](https://user-images.githubusercontent.com/22592497/153861092-0c505746-9f3a-43a9-aa89-0d13398fe3a6.png)

For data sets directly connected to a file, the "Overwrite" button would be disabled, with a tooltip explanation:

![image](https://user-images.githubusercontent.com/22592497/153861225-d3cb5f15-d4eb-4cb3-946b-9ae6ec14d586.png)

I've implemented this only for the filter dialog so far to have an example for detail discussions.

I'm not sure whether inheritance will be the best approach to add this ability to multiple dialogs, but had no better idea either, WDYT @cbrnr?