### PR TITLE
Use correct extension for export to .fif.gz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))
 - Fix exporting to BrainVision with annotations starting with "BAD" or "EDGE" ([#276](https://github.com/cbrnr/mnelab/pull/276) by [Clemens Brunner](https://github.com/cbrnr))
+- Exporting to .fif.gz now uses the correct extension on macOS ([#301](https://github.com/cbrnr/mnelab/pull/301) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.7.0] - 2021-12-29
 ### Added

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -532,17 +532,17 @@ class MainWindow(QMainWindow):
         """Export to file."""
         fname = QFileDialog.getSaveFileName(self, text, filter=ffilter)[0]
         if fname:
-            if ffilter != "*":
-                exts = [ext.replace("*", "") for ext in ffilter.split()]
+            exts = [ext.replace("*", "") for ext in ffilter.split()]
 
-                maxsuffixes = max([ext.count(".") for ext in exts])
-                suffixes = Path(fname).suffixes
-                for i in range(-maxsuffixes, 0):
-                    ext = "".join(suffixes[i:])
-                    if ext in exts:
-                        return f(fname)
-                fname = fname + exts[0]
-                return f(fname)
+            maxsuffixes = max([ext.count(".") for ext in exts])
+            suffixes = Path(fname).suffixes
+            for i in range(-maxsuffixes, 0):
+                ext = "".join(suffixes[i:])
+                if ext in exts:
+                    return f(fname)
+            parent = Path(fname).parent
+            name = Path(fname).name.removesuffix("".join(suffixes))
+            return f(parent / (name + exts[0]))
 
     def import_file(self, f, text, ffilter="*"):
         """Import file."""

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -530,19 +530,13 @@ class MainWindow(QMainWindow):
 
     def export_file(self, f, text, ffilter="*"):
         """Export to file."""
-        fname = QFileDialog.getSaveFileName(self, text, filter=ffilter)[0]
+        fname = QFileDialog.getSaveFileName(self, text)[0]
         if fname:
             exts = [ext.replace("*", "") for ext in ffilter.split()]
-
-            maxsuffixes = max([ext.count(".") for ext in exts])
-            suffixes = Path(fname).suffixes
-            for i in range(-maxsuffixes, 0):
-                ext = "".join(suffixes[i:])
-                if ext in exts:
+            for ext in exts:
+                if fname.endswith(ext):
                     return f(fname)
-            parent = Path(fname).parent
-            name = Path(fname).name.removesuffix("".join(suffixes))
-            return f(parent / (name + exts[0]))
+            return f(fname + exts[0])
 
     def import_file(self, f, text, ffilter="*"):
         """Import file."""


### PR DESCRIPTION
Previouly, export to .FIF.GZ exported to a file `<name>.gz.fif.gz`. For some reason, `QFileDialog` appends `.gz` when no extension is given in `<name>`.

This PR removes this extra `.gz` and correctly exports to `<name>.fif.gz`. Note that this means that it is impossible to export to a file named `<name>.gz.fif.gz`, but I think that's OK.

Fixes #300.