### PR TITLE
Let event selection dialogs show event labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add support for loading data from .MAT files ([#314](https://github.com/cbrnr/mnelab/pull/314) by [Clemens Brunner](https://github.com/cbrnr))
 - Add support for reading multiple XDF streams (via resampling) ([#312](https://github.com/cbrnr/mnelab/pull/312) by [Florian Hofer](https://github.com/hofaflo))
 - Add app icon ([#319](https://github.com/cbrnr/mnelab/pull/319) by [Clemens Brunner](https://github.com/cbrnr))
+- Add dialog to modify mapping between event IDs and labels (Edit - Events...) ([#302](https://github.com/cbrnr/mnelab/pull/302) by [Florian Hofer](https://github.com/hofaflo) and [Clemens Brunner](https://github.com/cbrnr))
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Stop requiring existing annotations or events to enable editing them ([#283](https://github.com/cbrnr/mnelab/pull/283) by [Florian Hofer](https://github.com/hofaflo))
 - Replace "(channels dropped)" suffix with "(channels picked)" and use `pick_channels` instead of `drop_channels` ([#285](https://github.com/cbrnr/mnelab/pull/285) by [Florian Hofer](https://github.com/hofaflo))
 - The overwrite confirmation dialog is now fail-safe because it defaults to creating a new dataset ([#304](https://github.com/cbrnr/mnelab/pull/304) by [Clemens Brunner](https://github.com/cbrnr))
+- Let event selection dialogs show event labels instead of integer ids ([#302](https://github.com/cbrnr/mnelab/pull/302) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Stop requiring existing annotations or events to enable editing them ([#283](https://github.com/cbrnr/mnelab/pull/283) by [Florian Hofer](https://github.com/hofaflo))
 - Replace "(channels dropped)" suffix with "(channels picked)" and use `pick_channels` instead of `drop_channels` ([#285](https://github.com/cbrnr/mnelab/pull/285) by [Florian Hofer](https://github.com/hofaflo))
 - The overwrite confirmation dialog is now fail-safe because it defaults to creating a new dataset ([#304](https://github.com/cbrnr/mnelab/pull/304) by [Clemens Brunner](https://github.com/cbrnr))
-- Let event selection dialogs show event labels instead of integer ids ([#302](https://github.com/cbrnr/mnelab/pull/302) by [Florian Hofer](https://github.com/hofaflo))
+- Dialogs where events can be selected now show both the integer IDs and the event labels ([#302](https://github.com/cbrnr/mnelab/pull/302) by [Florian Hofer](https://github.com/hofaflo))
 
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))

--- a/mnelab/dialogs/annotations.py
+++ b/mnelab/dialogs/annotations.py
@@ -56,6 +56,7 @@ class AnnotationsDialog(QDialog):
         self.remove_button.clicked.connect(self.toggle_buttons)
         self.add_button.clicked.connect(self.toggle_buttons)
         self.toggle_buttons()
+        self.setMinimumSize(500, 500)
         self.resize(500, 500)
 
     @Slot()

--- a/mnelab/dialogs/epoch.py
+++ b/mnelab/dialogs/epoch.py
@@ -2,7 +2,6 @@
 #
 # License: BSD (3-clause)
 
-from numpy import unique
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -26,7 +25,7 @@ class EpochDialog(QDialog):
         grid.addWidget(label, 0, 0, 1, 1)
 
         self.events = QListWidget()
-        self.events.insertItems(0, unique(events[:, 2]).astype(str))
+        self.events.insertItems(0, events)
         self.events.setSelectionMode(QListWidget.ExtendedSelection)
         grid.addWidget(self.events, 0, 1, 1, 2)
 

--- a/mnelab/dialogs/events.py
+++ b/mnelab/dialogs/events.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from .utils import IntTableWidgetItem, FloatTableWidgetItem
+from .utils import IntTableWidgetItem
 
 
 class EventsDialog(QDialog):

--- a/mnelab/dialogs/events.py
+++ b/mnelab/dialogs/events.py
@@ -2,14 +2,18 @@
 #
 # License: BSD (3-clause)
 
+from collections import defaultdict
+
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QDialog,
     QDialogButtonBox,
     QHBoxLayout,
+    QLabel,
     QPushButton,
     QTableWidget,
+    QTableWidgetItem,
     QVBoxLayout,
 )
 
@@ -17,50 +21,70 @@ from .utils import IntTableWidgetItem
 
 
 class EventsDialog(QDialog):
-    def __init__(self, parent, pos, desc):
+    def __init__(self, parent, pos, desc, event_mapping):
         super().__init__(parent)
         self.setWindowTitle("Edit Events")
 
-        self.table = QTableWidget(len(pos), 2)
+        self.event_table = QTableWidget(len(pos), 2)
 
         for row, (p, d) in enumerate(zip(pos, desc)):
-            self.table.setItem(row, 0, IntTableWidgetItem(p))
-            self.table.setItem(row, 1, IntTableWidgetItem(d))
+            self.event_table.setItem(row, 0, IntTableWidgetItem(p))
+            self.event_table.setItem(row, 1, IntTableWidgetItem(d))
 
-        self.table.setHorizontalHeaderLabels(["Position", "Type"])
-        self.table.horizontalHeader().setStretchLastSection(True)
-        self.table.verticalHeader().setVisible(False)
-        self.table.setShowGrid(False)
-        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.table.setSortingEnabled(True)
-        self.table.sortByColumn(0, Qt.AscendingOrder)
+        self.event_table.setHorizontalHeaderLabels(["Position", "Type"])
+        self.event_table.horizontalHeader().setStretchLastSection(True)
+        self.event_table.verticalHeader().setVisible(False)
+        self.event_table.setShowGrid(False)
+        self.event_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.event_table.setSortingEnabled(True)
+        self.event_table.sortByColumn(0, Qt.AscendingOrder)
 
-        vbox = QVBoxLayout(self)
-        vbox.addWidget(self.table)
+        self.event_mapping = defaultdict(str, event_mapping)
+        self.mapping_table = QTableWidget(0, 2)
+        self.mapping_table.setHorizontalHeaderLabels(["ID", "Label"])
+        self.mapping_table.horizontalHeader().setStretchLastSection(True)
+        self.mapping_table.verticalHeader().setVisible(False)
+        self.mapping_table.setShowGrid(False)
+        self.mapping_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.fill_mapping_table()
+        self.clear_button = QPushButton("Clear event mapping")
+
         hbox = QHBoxLayout()
         self.add_button = QPushButton("+")
         self.remove_button = QPushButton("-")
-        buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         hbox.addWidget(self.add_button)
         hbox.addWidget(self.remove_button)
-        hbox.addStretch()
-        hbox.addWidget(buttonbox)
+
+        vbox = QVBoxLayout(self)
+        vbox.addWidget(QLabel("Events:"))
+        vbox.addWidget(self.event_table)
         vbox.addLayout(hbox)
+        vbox.addWidget(QLabel("Event mapping:"))
+        vbox.addWidget(self.mapping_table)
+        vbox.addWidget(self.clear_button)
+
+        buttonbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        vbox.addWidget(buttonbox)
         buttonbox.accepted.connect(self.accept)
         buttonbox.rejected.connect(self.reject)
-        self.table.itemSelectionChanged.connect(self.toggle_buttons)
+        self.event_table.itemSelectionChanged.connect(self.toggle_buttons)
+        self.event_table.itemChanged.connect(self.fill_mapping_table)
+        self.mapping_table.itemChanged.connect(self.store_mapping)
         self.remove_button.clicked.connect(self.remove_event)
         self.add_button.clicked.connect(self.add_event)
         self.remove_button.clicked.connect(self.toggle_buttons)
         self.add_button.clicked.connect(self.toggle_buttons)
+        self.clear_button.clicked.connect(self.clear_mapping)
         self.toggle_buttons()
-        self.resize(300, 500)
+        self.event_table.setMinimumHeight(350)
+        self.mapping_table.setMinimumHeight(150)
+        self.resize(300, 700)
 
     @Slot()
     def toggle_buttons(self):
         """Toggle + and - buttons."""
-        n_items = len(self.table.selectedItems())
-        if self.table.rowCount() == 0:  # no events available
+        n_items = len(self.event_table.selectedItems())
+        if self.event_table.rowCount() == 0:  # no events available
             self.add_button.setEnabled(True)
             self.remove_button.setEnabled(False)
         elif n_items == 2:  # one row (2 items) selected
@@ -74,20 +98,51 @@ class EventsDialog(QDialog):
             self.remove_button.setEnabled(False)
 
     def add_event(self):
-        if self.table.selectedIndexes():
-            current_row = self.table.selectedIndexes()[0].row()
-            pos = int(self.table.item(current_row, 0).data(Qt.DisplayRole))
+        if self.event_table.selectedIndexes():
+            current_row = self.event_table.selectedIndexes()[0].row()
+            pos = int(self.event_table.item(current_row, 0).data(Qt.DisplayRole))
         else:
             current_row = 0
             pos = 0
-        self.table.setSortingEnabled(False)
-        self.table.insertRow(current_row)
-        self.table.setItem(current_row, 0, IntTableWidgetItem(pos))
-        self.table.setItem(current_row, 1, IntTableWidgetItem(0))
-        self.table.setSortingEnabled(True)
+        self.event_table.setSortingEnabled(False)
+        self.event_table.insertRow(current_row)
+        self.event_table.setItem(current_row, 0, IntTableWidgetItem(pos))
+        self.event_table.setItem(current_row, 1, IntTableWidgetItem(0))
+        self.event_table.setSortingEnabled(True)
 
     def remove_event(self):
-        rows = {index.row() for index in self.table.selectedIndexes()}
-        self.table.clearSelection()
+        rows = {index.row() for index in self.event_table.selectedIndexes()}
+        self.event_table.clearSelection()
         for row in sorted(rows, reverse=True):
-            self.table.removeRow(row)
+            self.event_table.removeRow(row)
+        self.fill_mapping_table()
+
+    def get_unique_events(self):
+        unique_events = set()
+        for i in range(self.event_table.rowCount()):
+            if item := self.event_table.item(i, 1):
+                unique_events.add(int(item.value()))
+        return unique_events
+
+    def fill_mapping_table(self):
+        unique_events = self.get_unique_events()
+        self.mapping_table.setRowCount(0)
+        for row, id_ in enumerate(sorted(unique_events)):
+            id_item = IntTableWidgetItem(id_)
+            id_item.setFlags(id_item.flags() ^ Qt.ItemIsEditable)
+            self.mapping_table.insertRow(row)
+            self.mapping_table.setItem(row, 0, id_item)
+            self.mapping_table.setItem(row, 1, QTableWidgetItem(self.event_mapping[id_]))
+
+    def store_mapping(self):
+        unique_events = self.get_unique_events()
+        for i in range(self.mapping_table.rowCount()):
+            event_id = int(self.mapping_table.item(i, 0).value())
+            if event_id not in unique_events:
+                del self.event_mapping[event_id]
+            if self.mapping_table.item(i, 1) is not None:
+                self.event_mapping[event_id] = self.mapping_table.item(i, 1).text()
+
+    def clear_mapping(self):
+        self.event_mapping.clear()
+        self.fill_mapping_table()

--- a/mnelab/dialogs/events.py
+++ b/mnelab/dialogs/events.py
@@ -16,15 +16,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from .utils import IntTableWidgetItem
-
-
-def _get_unique_events(event_table):
-    unique_events = set()
-    for i in range(event_table.rowCount()):
-        if item := event_table.item(i, 1):
-            unique_events.add(int(item.value()))
-    return unique_events
+from .utils import IntTableWidgetItem, FloatTableWidgetItem
 
 
 class EventsDialog(QDialog):
@@ -127,6 +119,12 @@ class EventMappingDialog(QDialog):
         self.setWindowTitle("Event Mapping")
         self.event_table = parent.event_table
         self.event_mapping = defaultdict(str, parent.event_mapping)  # make copy
+
+        self.unique_events = set()
+        for i in range(self.event_table.rowCount()):
+            if item := self.event_table.item(i, 1):
+                self.unique_events.add(int(item.value()))
+
         self.mapping_table = QTableWidget(0, 2)
         self.mapping_table.setHorizontalHeaderLabels(["Type", "Label"])
         self.mapping_table.horizontalHeader().setStretchLastSection(True)
@@ -153,9 +151,8 @@ class EventMappingDialog(QDialog):
         self.mapping_table.setMinimumHeight(150)
 
     def fill_mapping_table(self):
-        unique_events = _get_unique_events(self.event_table)
         self.mapping_table.setRowCount(0)
-        for row, id_ in enumerate(sorted(unique_events)):
+        for row, id_ in enumerate(sorted(self.unique_events)):
             id_item = IntTableWidgetItem(id_)
             id_item.setFlags(id_item.flags() ^ Qt.ItemIsEditable)
             self.mapping_table.insertRow(row)
@@ -163,10 +160,9 @@ class EventMappingDialog(QDialog):
             self.mapping_table.setItem(row, 1, QTableWidgetItem(self.event_mapping[id_]))
 
     def store_mapping(self):
-        unique_events = _get_unique_events(self.event_table)
         for i in range(self.mapping_table.rowCount()):
             event_id = int(self.mapping_table.item(i, 0).value())
-            if event_id not in unique_events:
+            if event_id not in self.unique_events:
                 del self.event_mapping[event_id]
             if self.mapping_table.item(i, 1) is not None:
                 self.event_mapping[event_id] = self.mapping_table.item(i, 1).text()

--- a/mnelab/dialogs/utils.py
+++ b/mnelab/dialogs/utils.py
@@ -30,3 +30,23 @@ class IntTableWidgetItem(QTableWidgetItem):
 
     def value(self):
         return int(self.data(Qt.DisplayRole))
+
+
+class FloatTableWidgetItem(QTableWidgetItem):
+    def __init__(self, value):
+        super().__init__(str(value))
+
+    def __lt__(self, other):
+        return float(self.data(Qt.EditRole)) < float(other.data(Qt.EditRole))
+
+    def setData(self, role, value):
+        try:
+            value = float(value)
+        except ValueError:
+            return
+        else:
+            if value >= 0:  # event position and type must not be negative
+                super().setData(role, str(value))
+
+    def value(self):
+        return float(self.data(Qt.DisplayRole))

--- a/mnelab/dialogs/utils.py
+++ b/mnelab/dialogs/utils.py
@@ -29,4 +29,4 @@ class IntTableWidgetItem(QTableWidgetItem):
                 super().setData(role, str(value))
 
     def value(self):
-        return float(self.data(Qt.DisplayRole))
+        return int(self.data(Qt.DisplayRole))

--- a/mnelab/dialogs/xdf_streams.py
+++ b/mnelab/dialogs/xdf_streams.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from .utils import IntTableWidgetItem
+from .utils import FloatTableWidgetItem, IntTableWidgetItem
 
 
 class XDFStreamsDialog(QDialog):
@@ -34,7 +34,7 @@ class XDFStreamsDialog(QDialog):
             self.view.setItem(i, 2, QTableWidgetItem(row[2]))
             self.view.setItem(i, 3, IntTableWidgetItem(row[3]))
             self.view.setItem(i, 4, QTableWidgetItem(row[4]))
-            self.view.setItem(i, 5, IntTableWidgetItem(row[5]))
+            self.view.setItem(i, 5, FloatTableWidgetItem(row[5]))
             if i in disabled:
                 for col in range(6):
                     self.view.item(i, col).setFlags(Qt.NoItemFlags)

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -1046,17 +1046,14 @@ class MainWindow(QMainWindow):
         """Epoch raw data."""
         unique_events = np.unique(self.model.current["events"][:, 2]).astype(str)
 
-        # If an event mapping exists, display the events as "ID (label)", e.g. "1 (hand)".
-        # Events without a label are displayed as "ID ()", e.g. "2 ()"
-        # if self.model.current["event_mapping"] is not None:
+        # Display the events as "ID (label)", e.g. "1 (hand)".
         event_id_to_label = defaultdict(str, self.model.current["event_mapping"])
         unique_events = [f"{e} ({event_id_to_label[int(e)]})" for e in unique_events]
 
         dialog = EpochDialog(self, unique_events)
         if dialog.exec():
-            # Create a dict {"ID (label)": ID, ...} (if an event mapping exists) or
-            # {"ID": ID} (if no event mapping exists). This is then passed to `mne.Epochs`
-            # as `event_id`, so the labels are also shown in plots and plotting dialogs.
+            # Create a dict {"ID (label)": ID, ...}. This is then passed to `mne.Epochs` as
+            # `event_id`, so the labels are also shown in plots and plotting dialogs.
             selected_events = {item.text(): int(item.text().split(" ")[0]) for item in dialog.events.selectedItems()}  # noqa: E501
 
             tmin = dialog.tmin.value()

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -499,8 +499,6 @@ class Model:
 
     @data_changed
     def epoch_data(self, events, tmin, tmax, baseline):
-        if self.current["event_mapping"] is not None:
-            events = {v: k for k, v in self.current["event_mapping"].items() if k in events}
         epochs = mne.Epochs(self.current["data"], self.current["events"], event_id=events,
                             tmin=tmin, tmax=tmax, baseline=baseline, preload=True)
         self.history.append(f"data = mne.Epochs(data, events, event_id={events}, "

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -126,6 +126,7 @@ class Model:
             dtype="raw",
             montage=None,
             events=np.empty((0, 3), dtype=int),
+            event_mapping={},
         ))
 
     @data_changed

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -499,6 +499,8 @@ class Model:
 
     @data_changed
     def epoch_data(self, events, tmin, tmax, baseline):
+        if self.current["event_mapping"] is not None:
+            events = {v: k for k, v in self.current["event_mapping"].items() if k in events}
         epochs = mne.Epochs(self.current["data"], self.current["events"], event_id=events,
                             tmin=tmin, tmax=tmax, baseline=baseline, preload=True)
         self.history.append(f"data = mne.Epochs(data, events, event_id={events}, "

--- a/mnelab/viz.py
+++ b/mnelab/viz.py
@@ -173,7 +173,7 @@ def plot_erds(tfr_and_masks):
             ax.label_outer()
         for ax in axes[..., -1].flat:
             fig.colorbar(axes.flat[0].images[-1], cax=ax)
-        fig.suptitle(f"ERDS ({event})")
+        fig.suptitle(f"ERDS – {event}")
         figs.append(fig)
     return figs
 


### PR DESCRIPTION
This lets dialogs in which users can select events show the event label instead of the integer id. If events aren't generated from annotations, but imported from a file, no event mapping exists, so the ids are shown. A future PR could introduce the possibility to change the event mapping.