### PR TITLE
Improve overwrite dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Replace `utils.has_location` with `utils.count_locations`, which returns the number of locations instead of a boolean ([#271](https://github.com/cbrnr/mnelab/pull/271) by [Florian Hofer](https://github.com/hofaflo))
 - Stop requiring existing annotations or events to enable editing them ([#283](https://github.com/cbrnr/mnelab/pull/283) by [Florian Hofer](https://github.com/hofaflo))
 - Replace "(channels dropped)" suffix with "(channels picked)" and use `pick_channels` instead of `drop_channels` ([#285](https://github.com/cbrnr/mnelab/pull/285) by [Florian Hofer](https://github.com/hofaflo))
+- The overwrite confirmation dialog is now fail-safe because it defaults to creating a new dataset ([#304](https://github.com/cbrnr/mnelab/pull/304) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -1111,17 +1111,20 @@ class MainWindow(QMainWindow):
             self.model.duplicate_data()
             return True
         # otherwise ask the user
-        msg = QMessageBox()
+        msg = QMessageBox(self)
+        msg.setWindowFlags(Qt.Dialog | Qt.WindowTitleHint | Qt.CustomizeWindowHint)
         msg.setWindowTitle("Modify data set")
         msg.setText("You are about to modify the current data set. How do you want to proceed?")  # noqa: E501
-        createnew_button = msg.addButton("Create new data set", QMessageBox.YesRole)
-        msg.addButton("Overwrite current data set", QMessageBox.NoRole)
-        msg.setDefaultButton(createnew_button)
+        create_button = msg.addButton("Create new data set", QMessageBox.AcceptRole)
+        overwrite_button = msg.addButton("Overwrite current data set", QMessageBox.RejectRole)  # noqa: E501
+        msg.setDefaultButton(create_button)
+        msg.setEscapeButton(create_button)
         msg.exec()
-        if msg.clickedButton() == createnew_button:
+        if msg.clickedButton() == overwrite_button:
+            return False
+        else:
             self.model.duplicate_data()
             return True
-        return False
 
     def _add_recent(self, fname):
         """Add a file to recent file list.


### PR DESCRIPTION
This PR disables (hides) the close window button in the overwrite dialog. It also makes sure that both the default button and pressing Escape is mapped to "Create new dataset" (so the current data is not accidentally overwritten).
<img width="532" alt="Screen Shot 2022-02-16 at 15 22 53" src="https://user-images.githubusercontent.com/4377312/154284289-20819157-967a-4e34-a9c5-4fe5bb79fdd3.png">
