### PR TITLE
Round pmin and pmax in EDF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))
 - Fix exporting to BrainVision with annotations starting with "BAD" or "EDGE" ([#276](https://github.com/cbrnr/mnelab/pull/276) by [Clemens Brunner](https://github.com/cbrnr))
 - Exporting to .fif.gz now uses the correct extension on macOS ([#301](https://github.com/cbrnr/mnelab/pull/301) by [Clemens Brunner](https://github.com/cbrnr))
+- Round physical minima and maxima to integers in EDF export ([#310](https://github.com/cbrnr/mnelab/pull/310) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.7.0] - 2021-12-29
 ### Added

--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -75,7 +75,7 @@ def write_edf(fname, raw):
             data[i] *= 1e6  # convert to microvolts
             dimension = "uV"
             prefilter = f"HP: {hp}; LP: {lp}"
-            pmin, pmax = data[i].min(), data[i].max()
+            pmin, pmax = int(data[i].min()), int(data[i].max())
             transducer = "Electrode"
         elif kind == "stim":
             dimension = "Boolean"


### PR DESCRIPTION
Rounding physical minima and maxima to integers avoids warnings when exporting to EDF. Since the data is converted to µV, integers are not a problem.