### PR TITLE
Add app icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add basic batch renaming of channels "Edit - Rename channels...") ([#303](https://github.com/cbrnr/mnelab/pull/303) by [Florian Hofer](https://github.com/hofaflo))
 - Add support for loading data from .MAT files ([#314](https://github.com/cbrnr/mnelab/pull/314) by [Clemens Brunner](https://github.com/cbrnr))
 - Add support for reading multiple XDF streams (via resampling) ([#312](https://github.com/cbrnr/mnelab/pull/312) by [Florian Hofer](https://github.com/hofaflo))
+- Add app icon ([#319](https://github.com/cbrnr/mnelab/pull/319) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))

--- a/mnelab/__init__.py
+++ b/mnelab/__init__.py
@@ -7,6 +7,7 @@ import sys
 
 import matplotlib
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication
 
 from .mainwindow import MainWindow
@@ -31,6 +32,9 @@ def main():
     app.setOrganizationName("cbrnr")
     if sys.platform.startswith("darwin"):
         app.setAttribute(Qt.ApplicationAttribute.AA_DontShowIconsInMenus, True)
+        app.setWindowIcon(QIcon("mnelab/icons/mnelab-logo-macos.svg"))
+    else:
+        app.setWindowIcon(QIcon("mnelab/icons/mnelab-logo.svg"))
     app.setAttribute(Qt.ApplicationAttribute.AA_UseHighDpiPixmaps)
     model = Model()
     model.view = MainWindow(model)

--- a/mnelab/__init__.py
+++ b/mnelab/__init__.py
@@ -21,6 +21,7 @@ def main():
     app_name = "MNELAB"
     if sys.platform.startswith("darwin"):
         # set bundle name on macOS (app name shown in the menu bar)
+        # this must be done before the app is created
         from Foundation import NSBundle
         bundle = NSBundle.mainBundle()
         info = bundle.localizedInfoDictionary() or bundle.infoDictionary()

--- a/mnelab/icons/mnelab-logo-macos.svg
+++ b/mnelab/icons/mnelab-logo-macos.svg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="70.835022mm"
+   height="70.835022mm"
+   viewBox="0 0 70.835022 70.835022"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.2 (b8e25be8, 2022-02-05)"
+   sodipodi:docname="mnelab-logo.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="4.4279789"
+     inkscape:cx="133.69531"
+     inkscape:cy="133.58239"
+     inkscape:window-width="2081"
+     inkscape:window-height="1505"
+     inkscape:window-x="354"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     fit-margin-top="6"
+     fit-margin-left="6"
+     fit-margin-right="6"
+     fit-margin-bottom="6"
+     lock-margins="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-page="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true">
+    <sodipodi:guide
+       position="8.4745506,35.41752"
+       orientation="0,-1"
+       id="guide12331" />
+    <sodipodi:guide
+       position="28.628544,46.435379"
+       orientation="1,0"
+       id="guide12333" />
+    <sodipodi:guide
+       position="35.417505,62.360468"
+       orientation="1,0"
+       id="guide12636" />
+    <sodipodi:guide
+       position="28.163184,46.900739"
+       orientation="0,-1"
+       id="guide12946" />
+    <sodipodi:guide
+       position="42.206468,35.88289"
+       orientation="1,0"
+       id="guide12948" />
+    <sodipodi:guide
+       position="44.230715,23.93431"
+       orientation="0,-1"
+       id="guide12972" />
+    <sodipodi:guide
+       position="21.83958,38.046633"
+       orientation="1,0"
+       id="guide4833" />
+    <sodipodi:guide
+       position="48.995431,33.046627"
+       orientation="1,0"
+       id="guide5019" />
+    <sodipodi:guide
+       position="15.050616,38.046633"
+       orientation="1,0"
+       id="guide5227" />
+    <sodipodi:guide
+       position="55.784394,38.285647"
+       orientation="1,0"
+       id="guide5229" />
+    <sodipodi:guide
+       position="18.445098,43.563089"
+       orientation="1,0"
+       id="guide5415" />
+    <sodipodi:guide
+       position="52.389913,40.018473"
+       orientation="1,0"
+       id="guide5417" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9338">
+      <stop
+         style="stop-color:#f76420;stop-opacity:1;"
+         offset="0"
+         id="stop9334" />
+      <stop
+         style="stop-color:#294afe;stop-opacity:1"
+         offset="1"
+         id="stop9336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3157"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3155" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9338"
+       id="linearGradient9340"
+       x1="100.58579"
+       y1="7.6979885"
+       x2="134.20282"
+       y2="7.6979885"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-42.149502,-53.036098)">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.69183;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5597"
+       width="58.835018"
+       height="58.835018"
+       x="48.149502"
+       y="59.036098"
+       rx="10" />
+    <rect
+       style="fill:url(#linearGradient9340);fill-opacity:1;stroke:#323232;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7207"
+       width="32.117031"
+       height="32.117031"
+       x="101.33579"
+       y="-8.360527"
+       transform="rotate(45)"
+       rx="5" />
+    <path
+       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 72.135698,79.266954 H 82.998037"
+       id="path3840" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064"
+       cx="72.135696"
+       cy="79.26696"
+       r="1.6013702" />
+    <path
+       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 82.998037,79.266954 72.135698,88.45353"
+       id="path4220" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-7"
+       cx="63.988941"
+       cy="88.453529"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-7-6"
+       cx="91.144798"
+       cy="88.453529"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-8"
+       cx="82.998039"
+       cy="79.26696"
+       r="1.6013702" />
+    <path
+       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 82.998037,97.640099 72.135698,88.45353"
+       id="path4222" />
+    <path
+       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 82.998038,97.640098 H 72.135697"
+       id="path8331" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-1"
+       cx="72.135696"
+       cy="88.453529"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-6"
+       cx="82.998039"
+       cy="88.453529"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-11"
+       cx="82.998039"
+       cy="97.640099"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-4"
+       cx="72.135696"
+       cy="97.640099"
+       r="1.6013702" />
+  </g>
+</svg>

--- a/mnelab/icons/mnelab-logo.svg
+++ b/mnelab/icons/mnelab-logo.svg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="70.835022mm"
+   height="70.835022mm"
+   viewBox="0 0 70.835022 70.835022"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.2 (b8e25be8, 2022-02-05)"
+   sodipodi:docname="mnelab-logo.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="4.4279789"
+     inkscape:cx="150.85889"
+     inkscape:cy="133.58239"
+     inkscape:window-width="1920"
+     inkscape:window-height="1071"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     fit-margin-top="6"
+     fit-margin-left="6"
+     fit-margin-right="6"
+     fit-margin-bottom="6"
+     lock-margins="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-page="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true">
+    <sodipodi:guide
+       position="8.4745506,35.41752"
+       orientation="0,-1"
+       id="guide12331" />
+    <sodipodi:guide
+       position="28.628544,46.435379"
+       orientation="1,0"
+       id="guide12333" />
+    <sodipodi:guide
+       position="35.417505,62.360468"
+       orientation="1,0"
+       id="guide12636" />
+    <sodipodi:guide
+       position="28.163184,46.900739"
+       orientation="0,-1"
+       id="guide12946" />
+    <sodipodi:guide
+       position="42.206468,35.88289"
+       orientation="1,0"
+       id="guide12948" />
+    <sodipodi:guide
+       position="44.230715,23.93431"
+       orientation="0,-1"
+       id="guide12972" />
+    <sodipodi:guide
+       position="21.83958,38.046633"
+       orientation="1,0"
+       id="guide4833" />
+    <sodipodi:guide
+       position="48.995431,33.046627"
+       orientation="1,0"
+       id="guide5019" />
+    <sodipodi:guide
+       position="15.050616,38.046633"
+       orientation="1,0"
+       id="guide5227" />
+    <sodipodi:guide
+       position="55.784394,38.285647"
+       orientation="1,0"
+       id="guide5229" />
+    <sodipodi:guide
+       position="18.445098,43.563089"
+       orientation="1,0"
+       id="guide5415" />
+    <sodipodi:guide
+       position="52.389913,40.018473"
+       orientation="1,0"
+       id="guide5417" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9338">
+      <stop
+         style="stop-color:#f76420;stop-opacity:1;"
+         offset="0"
+         id="stop9334" />
+      <stop
+         style="stop-color:#294afe;stop-opacity:1"
+         offset="1"
+         id="stop9336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3157"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3155" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9338"
+       id="linearGradient9340"
+       x1="100.58579"
+       y1="7.6979885"
+       x2="134.20282"
+       y2="7.6979885"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-42.149502,-53.036098)">
+    <rect
+       style="fill:url(#linearGradient9340);fill-opacity:1;stroke:#323232;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7207"
+       width="32.117031"
+       height="32.117031"
+       x="101.33579"
+       y="-8.360527"
+       transform="rotate(45)"
+       rx="5" />
+    <path
+       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 72.135698,79.266954 H 82.998037"
+       id="path3840" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064"
+       cx="72.135696"
+       cy="79.26696"
+       r="1.6013702" />
+    <path
+       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 82.998037,79.266954 72.135698,88.45353"
+       id="path4220" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-7"
+       cx="63.988941"
+       cy="88.453529"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-7-6"
+       cx="91.144798"
+       cy="88.453529"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-8"
+       cx="82.998039"
+       cy="79.26696"
+       r="1.6013702" />
+    <path
+       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 82.998037,97.640099 72.135698,88.45353"
+       id="path4222" />
+    <path
+       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 82.998038,97.640098 H 72.135697"
+       id="path8331" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-1"
+       cx="72.135696"
+       cy="88.453529"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-6"
+       cx="82.998039"
+       cy="88.453529"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-11"
+       cx="82.998039"
+       cy="97.640099"
+       r="1.6013702" />
+    <circle
+       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+       id="path1064-4"
+       cx="72.135696"
+       cy="97.640099"
+       r="1.6013702" />
+  </g>
+</svg>

--- a/mnelab/icons/mnelab-logo.svg
+++ b/mnelab/icons/mnelab-logo.svg
@@ -24,9 +24,9 @@
      inkscape:pagecheckerboard="0"
      inkscape:document-units="mm"
      showgrid="false"
-     inkscape:zoom="4.4279789"
-     inkscape:cx="150.85889"
-     inkscape:cy="133.58239"
+     inkscape:zoom="0.5"
+     inkscape:cx="133"
+     inkscape:cy="133"
      inkscape:window-width="1920"
      inkscape:window-height="1071"
      inkscape:window-x="0"
@@ -131,78 +131,82 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(-42.149502,-53.036098)">
-    <rect
-       style="fill:url(#linearGradient9340);fill-opacity:1;stroke:#323232;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect7207"
-       width="32.117031"
-       height="32.117031"
-       x="101.33579"
-       y="-8.360527"
-       transform="rotate(45)"
-       rx="5" />
-    <path
-       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 72.135698,79.266954 H 82.998037"
-       id="path3840" />
-    <circle
-       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
-       id="path1064"
-       cx="72.135696"
-       cy="79.26696"
-       r="1.6013702" />
-    <path
-       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 82.998037,79.266954 72.135698,88.45353"
-       id="path4220" />
-    <circle
-       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
-       id="path1064-7"
-       cx="63.988941"
-       cy="88.453529"
-       r="1.6013702" />
-    <circle
-       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
-       id="path1064-7-6"
-       cx="91.144798"
-       cy="88.453529"
-       r="1.6013702" />
-    <circle
-       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
-       id="path1064-8"
-       cx="82.998039"
-       cy="79.26696"
-       r="1.6013702" />
-    <path
-       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 82.998037,97.640099 72.135698,88.45353"
-       id="path4222" />
-    <path
-       style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
-       d="M 82.998038,97.640098 H 72.135697"
-       id="path8331" />
-    <circle
-       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
-       id="path1064-1"
-       cx="72.135696"
-       cy="88.453529"
-       r="1.6013702" />
-    <circle
-       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
-       id="path1064-6"
-       cx="82.998039"
-       cy="88.453529"
-       r="1.6013702" />
-    <circle
-       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
-       id="path1064-11"
-       cx="82.998039"
-       cy="97.640099"
-       r="1.6013702" />
-    <circle
-       style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
-       id="path1064-4"
-       cx="72.135696"
-       cy="97.640099"
-       r="1.6013702" />
+    <g
+       id="g952"
+       transform="matrix(1.5,0,0,1.5,-38.783506,-44.226806)">
+      <rect
+         style="fill:url(#linearGradient9340);fill-opacity:1;stroke:#323232;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect7207"
+         width="32.117031"
+         height="32.117031"
+         x="101.33579"
+         y="-8.360527"
+         transform="rotate(45)"
+         rx="5" />
+      <path
+         style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 72.135698,79.266954 H 82.998037"
+         id="path3840" />
+      <circle
+         style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+         id="path1064"
+         cx="72.135696"
+         cy="79.26696"
+         r="1.6013702" />
+      <path
+         style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 82.998037,79.266954 72.135698,88.45353"
+         id="path4220" />
+      <circle
+         style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+         id="path1064-7"
+         cx="63.988941"
+         cy="88.453529"
+         r="1.6013702" />
+      <circle
+         style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+         id="path1064-7-6"
+         cx="91.144798"
+         cy="88.453529"
+         r="1.6013702" />
+      <circle
+         style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+         id="path1064-8"
+         cx="82.998039"
+         cy="79.26696"
+         r="1.6013702" />
+      <path
+         style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 82.998037,97.640099 72.135698,88.45353"
+         id="path4222" />
+      <path
+         style="fill:none;stroke:#323232;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 82.998038,97.640098 H 72.135697"
+         id="path8331" />
+      <circle
+         style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+         id="path1064-1"
+         cx="72.135696"
+         cy="88.453529"
+         r="1.6013702" />
+      <circle
+         style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+         id="path1064-6"
+         cx="82.998039"
+         cy="88.453529"
+         r="1.6013702" />
+      <circle
+         style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+         id="path1064-11"
+         cx="82.998039"
+         cy="97.640099"
+         r="1.6013702" />
+      <circle
+         style="fill:#323232;fill-opacity:1;stroke:none;stroke-width:0.08;stroke-linecap:round"
+         id="path1064-4"
+         cx="72.135696"
+         cy="97.640099"
+         r="1.6013702" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
This needs to be tested on Windows, macOS, and Linux. It might not be possible to make this 100% work without creating a standalone version (see https://doc.qt.io/qt-6/appicon.html), but maybe it can be good enough.

One minor thing I noticed is that when quitting MNELAB on macOS, the default Python rocket icon is briefly visible. But I guess that's not too bad.