### PR TITLE
Add complete history for find_events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add support for reading multiple XDF streams (via resampling) ([#312](https://github.com/cbrnr/mnelab/pull/312) by [Florian Hofer](https://github.com/hofaflo))
 - Add app icon ([#319](https://github.com/cbrnr/mnelab/pull/319) by [Clemens Brunner](https://github.com/cbrnr))
 - Add dialog to modify mapping between event IDs and labels (Edit - Events...) ([#302](https://github.com/cbrnr/mnelab/pull/302) by [Florian Hofer](https://github.com/hofaflo) and [Clemens Brunner](https://github.com/cbrnr))
+- Add complete history for Find Events dialog ([#333](https://github.com/cbrnr/mnelab/pull/333) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Changed
 - Simplify rereferencing workflow ([#258](https://github.com/cbrnr/mnelab/pull/258) by [Florian Hofer](https://github.com/hofaflo))

--- a/mnelab/dialogs/find_events.py
+++ b/mnelab/dialogs/find_events.py
@@ -30,8 +30,9 @@ class FindEventsDialog(QDialog):
         grid.addWidget(self.stimchan, 0, 1)
 
         grid.addWidget(QLabel("Consecutive"), 1, 0)
-        self.consecutive = QCheckBox()
-        self.consecutive.setChecked(True)
+        self.consecutive = QComboBox()
+        self.consecutive.addItems(["Increasing", "True", "False"])
+        self.consecutive.setCurrentIndex(0)
         grid.addWidget(self.consecutive, 1, 1)
 
         grid.addWidget(QLabel("Initial event"), 2, 0)
@@ -39,7 +40,7 @@ class FindEventsDialog(QDialog):
         self.initial_event.setChecked(True)
         grid.addWidget(self.initial_event, 2, 1)
 
-        grid.addWidget(QLabel("Cast to unsigned integer"), 3, 0)
+        grid.addWidget(QLabel("Interpret as uint16"), 3, 0)
         self.uint_cast = QCheckBox()
         self.uint_cast.setChecked(True)
         grid.addWidget(self.uint_cast, 3, 1)
@@ -51,6 +52,7 @@ class FindEventsDialog(QDialog):
 
         grid.addWidget(QLabel("Shortest event:"), 5, 0)
         self.shortesteventedit = QSpinBox()
+        self.shortesteventedit.setValue(2)
         self.shortesteventedit.setMaximum(MAX_INT)
         grid.addWidget(self.shortesteventedit, 5, 1)
 

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -1022,7 +1022,11 @@ class MainWindow(QMainWindow):
         dialog = FindEventsDialog(self, info["ch_names"], default_stim)
         if dialog.exec():
             stim_channel = dialog.stimchan.currentText()
-            consecutive = dialog.consecutive.isChecked()
+            consecutive = dialog.consecutive.currentText().lower()
+            if consecutive == "true":
+                consecutive = True
+            elif consecutive == "false":
+                consecutive = False
             initial_event = dialog.initial_event.isChecked()
             uint_cast = dialog.uint_cast.isChecked()
             min_dur = dialog.minduredit.value()

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -144,7 +144,20 @@ class Model:
         )
         if events.shape[0] > 0:  # if events were found
             self.current["events"] = events
-            self.history.append("events = mne.find_events(data)")
+            hist = "events = mne.find_events(data"
+            hist += f", stim_channel={stim_channel!r}"
+            if consecutive != "increasing":
+                hist += f", consecutive={consecutive!r}"
+            if initial_event:
+                hist += f", initial_event={initial_event!r}"
+            if uint_cast:
+                hist += f", uint_cast={uint_cast!r}"
+            if min_duration > 0:
+                hist += f", min_duration={min_duration!r}"
+            if shortest_event != 2:
+                hist += f", shortest_event={shortest_event!r}"
+            hist += ")"
+            self.history.append(hist)
 
     @data_changed
     def events_from_annotations(self):

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -130,8 +130,15 @@ class Model:
         ))
 
     @data_changed
-    def find_events(self, stim_channel, consecutive=True, initial_event=True,
-                    uint_cast=True, min_duration=0, shortest_event=0):
+    def find_events(
+        self,
+        stim_channel,
+        consecutive=True,
+        initial_event=True,
+        uint_cast=True,
+        min_duration=0,
+        shortest_event=0
+    ):
         """Find events in raw data."""
         events = mne.find_events(
             self.current["data"],


### PR DESCRIPTION
This adds proper history for the Find Events dialog. The argument `consecutive` now also supports `"increasing"` (the default) in addition to `True` and `False`. Fixes #331.