### PR TITLE
More readable signal lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Stop requiring existing annotations or events to enable editing them ([#283](https://github.com/cbrnr/mnelab/pull/283) by [Florian Hofer](https://github.com/hofaflo))
 - Replace "(channels dropped)" suffix with "(channels picked)" and use `pick_channels` instead of `drop_channels` ([#285](https://github.com/cbrnr/mnelab/pull/285) by [Florian Hofer](https://github.com/hofaflo))
 - The overwrite confirmation dialog is now fail-safe because it defaults to creating a new dataset ([#304](https://github.com/cbrnr/mnelab/pull/304) by [Clemens Brunner](https://github.com/cbrnr))
+- Show signal length in hours, minutes, and seconds ([#334](https://github.com/cbrnr/mnelab/pull/334) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
 - Fix splitting name and extension for compatibility with Python 3.8 ([#252](https://github.com/cbrnr/mnelab/pull/252) by [Johan Medrano](https://github.com/yop0))

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -313,8 +313,21 @@ class Model:
         montage = self.current["montage"]
         ica = self.current["ica"]
 
-        length = f"{data.times[-1] - data.times[0]:.6g} s"
-        samples = f"{len(data.times)}"
+        fs = data.info["sfreq"]
+        n_samples = len(data.times)
+        samples = f"{n_samples:,}".replace(",", "\u2009")
+
+        seconds = n_samples / fs
+        minutes, seconds = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        hours, minutes = int(hours), int(minutes)
+        if hours > 0:
+            length = f"{hours}\u2009h {minutes}\u2009m {seconds:.3g}\u2009s"
+        elif minutes > 0:
+            length = f"{minutes}\u2009m {seconds:.3g}\u2009s"
+        else:
+            length = f"{seconds:.3g}\u2009s"
+
         if self.current["dtype"] == "epochs":  # add epoch count
             length = f"{self.current['data'].events.shape[0]} x {length}"
             samples = f"{self.current['data'].events.shape[0]} x {samples}"
@@ -378,7 +391,7 @@ class Model:
                 "Size in memory": f"{data.get_data().nbytes / 1024**2:.2f} MB",
                 "Channels": f"{nchan} (" + chans + ")",
                 "Samples": samples,
-                "Sampling frequency": f"{data.info['sfreq']:.6g} Hz",
+                "Sampling frequency": f"{fs:.6g} Hz",
                 "Length": length,
                 "Events": events,
                 "Annotations": annots,


### PR DESCRIPTION
Fixes #330. Depending on the actual length, this shows either h m s, m s, or just s.