### PR TITLE
Show more on events in info widget

### DIFF
--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -345,14 +345,17 @@ class Model:
         chans = ", ".join([" ".join([str(v), k.upper()]) for k, v in chans])
 
         if events is not None and events.shape[0] > 0:
-            nevents = events.shape[0]
-            unique = [str(e) for e in sorted(set(events[:, 2]))]
-            if len(unique) > 20:  # do not show all events
-                first = ", ".join(unique[:10])
-                last = ", ".join(unique[-10:])
-                events = f"{nevents} ({first + ', ..., ' + last})"
+            unique, counts = np.unique(events[:, 2], return_counts=True)
+            events = f"{events.shape[0]} ("
+            if len(unique) < 8:
+                events += ", ".join([f"{u}: {c}" for u, c in zip(unique, counts)])
+            elif 8 <= len(unique) <= 12:
+                events += ", ".join([f"{u}" for u in unique])
             else:
-                events = f"{nevents} ({', '.join(unique)})"
+                first = ", ".join([f"{u}" for u in unique[:6]])
+                last = ", ".join([f"{u}" for u in unique[-6:]])
+                events += f"{first}, ..., {last}"
+            events += ")"
         else:
             events = "-"
 


### PR DESCRIPTION
Partially addresses #329.

This changes how events are shown in the info widget:
- The total number of events is always shown
- If there are fewer than 8 unique event types, the count for each type is shown in parentheses.
- If there are between 8 and 12 unique event types, only the unique event types are shown in parentheses.
- If there are more than 12 unique event types, only the first 6 and last 6 unique event types are shown in parentheses (with a `...` in between).

To completely fix #329, there needs to be an option which shows the counts of all unique event types (in addition to the total count). Maybe in the "Events" dialog?