### PR TITLE
ENH: wait_cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [UNRELEASED] - XXXX-XX-XX
 ### Added
-- Change the default cursor to a spinning wheel on linux when the data is changed ([#341](https://github.com/cbrnr/mnelab/pull/341) by [Guillaume Favelier](https://github.com/GuillaumeFavelier))
+- Change the default cursor to a spinning wheel when the data is changed ([#341](https://github.com/cbrnr/mnelab/pull/341) by [Guillaume Favelier](https://github.com/GuillaumeFavelier))
 
 ## [0.8.1] - 2022-03-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - XXXX-XX-XX
+### Added
+- Change the default cursor to a spinning wheel on linux when the data is changed ([#341](https://github.com/cbrnr/mnelab/pull/341) by [Guillaume Favelier](https://github.com/GuillaumeFavelier))
 
 ## [0.8.1] - 2022-03-29
 ### Fixed

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -8,6 +8,7 @@ import traceback
 from functools import partial
 from pathlib import Path
 from sys import version_info
+from contextlib import contextmanager
 
 import mne
 import numpy as np
@@ -389,6 +390,15 @@ class MainWindow(QMainWindow):
             The target index.
         """
         self.model.move_data(start, row)
+
+    @contextmanager
+    def _wait_cursor(self):
+        default_cursor = self.cursor()
+        self.setCursor(Qt.WaitCursor)
+        try:
+            yield
+        finally:
+            self.setCursor(default_cursor)
 
     def data_changed(self):
         # update sidebar

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -5,10 +5,10 @@
 import multiprocessing as mp
 import sys
 import traceback
+from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
 from sys import version_info
-from contextlib import contextmanager
 
 import mne
 import numpy as np

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -393,12 +393,16 @@ class MainWindow(QMainWindow):
 
     @contextmanager
     def _wait_cursor(self):
-        default_cursor = self.cursor()
-        self.setCursor(Qt.WaitCursor)
-        try:
+        # disabled on macOS because of outdated icon
+        if sys.platform.startswith("darwin"):
             yield
-        finally:
-            self.setCursor(default_cursor)
+        else:
+            default_cursor = self.cursor()
+            self.setCursor(Qt.WaitCursor)
+            try:
+                yield
+            finally:
+                self.setCursor(default_cursor)
 
     def data_changed(self):
         # update sidebar

--- a/mnelab/model.py
+++ b/mnelab/model.py
@@ -32,8 +32,9 @@ def data_changed(f):
     """Call self.view.data_changed method after function call."""
     @wraps(f)
     def wrapper(*args, **kwargs):
-        f(*args, **kwargs)
-        args[0].view.data_changed()
+        with args[0].view._wait_cursor():
+            f(*args, **kwargs)
+            args[0].view.data_changed()
     return wrapper
 
 


### PR DESCRIPTION
This PR changes the current cursor to `Qt.WaitCursor`, effectively the "spinning wheel" mentioned in https://github.com/cbrnr/mnelab/issues/308, during a `data_changed` task. I went with `data_changed` because I thought it would be more impactful but maybe it's not the best place.

Here is how it looks for me:

https://user-images.githubusercontent.com/18143289/161078577-09984e53-1d41-42ae-b0f8-c220fc7e1ec3.mp4

Closes https://github.com/cbrnr/mnelab/issues/308