### PR TITLE
WIP,ENH: info widget shortcuts

### DIFF
--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -360,7 +360,7 @@ class MainWindow(QMainWindow):
 
         self.setAcceptDrops(True)
         self.data_changed()
-        self.infowidget.set_values(shortcuts)
+        self.infowidget.set_values(shortcuts, shortcut=True)
 
     def _excepthook(self, type, value, traceback_):
         exception_text = str(value)

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -1331,4 +1331,8 @@ class MainWindow(QMainWindow):
                 QIcon.setThemeName(style)
             else:
                 QIcon.setThemeName("light")  # fallback
+            # update shortcuts stylesheet if necessary
+            if hasattr(self, "infowidget"):
+                if self.infowidget._shortcut:
+                    self.infowidget.set_shortcuts()
         return super().event(ev)

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -277,7 +277,7 @@ class MainWindow(QMainWindow):
 
         view_menu = self.menuBar().addMenu("&View")
         self.actions["history"] = view_menu.addAction("&History", self.show_history,
-                                                      QKeySequence(Qt.CTRL + Qt.Key_H))
+                                                      QKeySequence(Qt.CTRL + Qt.Key_Y))
         self.actions["toolbar"] = view_menu.addAction("&Toolbar", self._toggle_toolbar)
         self.actions["toolbar"].setCheckable(True)
         self.actions["statusbar"] = view_menu.addAction("&Statusbar",

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -276,7 +276,8 @@ class MainWindow(QMainWindow):
         )
 
         view_menu = self.menuBar().addMenu("&View")
-        self.actions["history"] = view_menu.addAction("&History", self.show_history)
+        self.actions["history"] = view_menu.addAction("&History", self.show_history,
+                                                      QKeySequence(Qt.CTRL + Qt.Key_H))
         self.actions["toolbar"] = view_menu.addAction("&Toolbar", self._toggle_toolbar)
         self.actions["toolbar"].setCheckable(True)
         self.actions["statusbar"] = view_menu.addAction("&Statusbar",

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -336,13 +336,6 @@ class MainWindow(QMainWindow):
         splitter = QSplitter()
         splitter.addWidget(self.sidebar)
 
-        # describe the shortcuts
-        shortcuts = dict()
-        for action in self.actions.values():
-            if not action.shortcut().isEmpty():
-                action_text = action.text().replace('&', '')
-                shortcuts[action_text] = action.shortcut().toString()
-
         self.infowidget = InfoWidget()
         splitter.addWidget(self.infowidget)
         width = splitter.size().width()
@@ -360,7 +353,7 @@ class MainWindow(QMainWindow):
 
         self.setAcceptDrops(True)
         self.data_changed()
-        self.infowidget.set_values(shortcuts, shortcut=True)
+        self.infowidget.set_shortcuts()
 
     def _excepthook(self, type, value, traceback_):
         exception_text = str(value)

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -404,7 +404,7 @@ class MainWindow(QMainWindow):
         if self.model.data:
             self.infowidget.set_values(self.model.get_info())
         else:
-            self.infowidget.clear()
+            self.infowidget.set_shortcuts()
 
         # update status bar
         if self.model.data:

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -336,6 +336,13 @@ class MainWindow(QMainWindow):
         splitter = QSplitter()
         splitter.addWidget(self.sidebar)
 
+        # describe the shortcuts
+        shortcuts = dict()
+        for action in self.actions.values():
+            if not action.shortcut().isEmpty():
+                action_text = action.text().replace('&', '')
+                shortcuts[action_text] = action.shortcut().toString()
+
         self.infowidget = InfoWidget()
         splitter.addWidget(self.infowidget)
         width = splitter.size().width()
@@ -353,6 +360,7 @@ class MainWindow(QMainWindow):
 
         self.setAcceptDrops(True)
         self.data_changed()
+        self.infowidget.set_values(shortcuts)
 
     def _excepthook(self, type, value, traceback_):
         exception_text = str(value)

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+import sys
+
 from PySide6.QtWidgets import (QGridLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget,
                                QPushButton, QHBoxLayout)
 
@@ -59,6 +61,8 @@ class InfoWidget(QWidget):
 
         keys = right.split('+')
         for key in keys:
+            if sys.platform.startswith("darwin"):
+                key = key.replace('Ctrl', '⌘')
             button = QPushButton(key)
             button.setStyleSheet(self._get_shortcut_style())
             button.setProperty("class", "shortcut")

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -18,9 +18,7 @@ class InfoWidget(QWidget):
         super().__init__()
         vbox = QVBoxLayout(self)
         self.grid = QGridLayout()
-        self.grid.setColumnStretch(1, 1)
         vbox.addLayout(self.grid)
-        vbox.addStretch(1)
         self.set_values(values)
 
     def _get_shortcut_style(self):
@@ -43,23 +41,23 @@ class InfoWidget(QWidget):
         right.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
         self.grid.addWidget(right, row, 1)
 
-    def _add_shortcut(self, row, left, right):
+    def _add_shortcut_entry(self, row, left, right):
+        hbox = QHBoxLayout()
+        hbox.addStretch(1)
+
         left = left.replace('...', '')
         left = QLabel(left)
-        spacer = QWidget()
-        self.grid.addWidget(left, row, 0)
+        hbox.addWidget(left)
 
         keys = right.split('+')
-        right = QHBoxLayout()
         for key in keys:
             button = QPushButton(key)
             button.setStyleSheet(self._get_shortcut_style())
             button.setProperty("class", "shortcut")
-            right.addWidget(button)
-        spacer = QWidget()
-        spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
-        right.addWidget(spacer)
-        self.grid.addLayout(right, row, 1)
+            hbox.addWidget(button)
+        hbox.addStretch(1)
+
+        self.grid.addLayout(hbox, row, 0)
 
     def set_values(self, values=None, shortcut=False):
         """Set values (and overwrite existing values).
@@ -70,12 +68,18 @@ class InfoWidget(QWidget):
             Each key/value pair in this dict is displayed in a row separated by a colon.
         """
         self.clear()
+        if shortcut:
+            self.grid.setColumnStretch(1, 0)
+            self.layout().takeAt(1)  # remove vertical stretch
+        else:
+            self.grid.setColumnStretch(1, 1)
+            self.layout().addStretch(1)
         if values:
             for row, (key, value) in enumerate(values.items()):
                 left = str(key)
                 right = str(value)
                 if shortcut:
-                    self._add_shortcut(row, left, right)
+                    self._add_shortcut_entry(row, left, right)
                 else:
                     self._add_text_entry(row, left, right)
 
@@ -86,7 +90,9 @@ class InfoWidget(QWidget):
             if isinstance(item, QHBoxLayout):
                 sub = item.takeAt(0)
                 while sub:
-                    sub.widget().deleteLater()
+                    if sub.widget() is not None:
+                        sub.widget().deleteLater()
+                    del sub
                     sub = item.takeAt(0)
             else:
                 item.widget().deleteLater()

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -27,6 +27,7 @@ class InfoWidget(QWidget):
     """
     def __init__(self, values=None):
         super().__init__()
+        self._shortcut = False
         vbox = QVBoxLayout(self)
         self.grid = QGridLayout()
         vbox.addLayout(self.grid)
@@ -99,6 +100,7 @@ class InfoWidget(QWidget):
         shortcut : bool
             Whether the values describe shortcuts or not. Defaults to False.
         """
+        self._shortcut = shortcut
         self.clear()
         self.layout().takeAt(1)  # remove vertical stretch
         if shortcut:

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -34,9 +34,7 @@ class InfoWidget(QWidget):
         self.set_values(shortcuts, shortcut=True)
 
     def _get_shortcut_style(self):
-        stylesheet = " \
-            .shortcut { \
-        "
+        stylesheet = ".shortcut {"
         style = interface_style()
         if style is None:
             style = 'light'
@@ -44,21 +42,17 @@ class InfoWidget(QWidget):
             stylesheet += "  \
                     background-color:#ededed; \
                     color:#666666; \
-                    border:2px solid #dcdcdc; \
-            "
+                    border:2px solid #dcdcdc;"
         else:
             stylesheet += "  \
                     background-color:#131313; \
                     color:#9a9a9a; \
-                    border:2px solid #242424; \
-            "
+                    border:2px solid #242424;"
         stylesheet += " \
                 border-radius:5px; \
                 font-size:15px; \
                 font-weight:bold; \
-                padding:8px 8px; \
-            } \
-        "
+                padding:8px 8px;}"
         return stylesheet
 
     def _add_text_entry(self, row, left, right):

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -7,6 +7,8 @@ import sys
 from PySide6.QtWidgets import (QGridLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget,
                                QPushButton, QHBoxLayout)
 
+from ..utils import interface_style
+
 
 class InfoWidget(QWidget):
     """Display basic file information in a table (two columns).
@@ -32,17 +34,32 @@ class InfoWidget(QWidget):
         self.set_values(shortcuts, shortcut=True)
 
     def _get_shortcut_style(self):
-        return " \
+        stylesheet = " \
             .shortcut { \
-                background-color:#ededed; \
+        "
+        style = interface_style()
+        if style is None:
+            style = 'light'
+        if style == 'light':
+            stylesheet += "  \
+                    background-color:#ededed; \
+                    color:#666666; \
+                    border:2px solid #dcdcdc; \
+            "
+        else:
+            stylesheet += "  \
+                    background-color:#131313; \
+                    color:#9a9a9a; \
+                    border:2px solid #242424; \
+            "
+        stylesheet += " \
                 border-radius:5px; \
-                border:2px solid #dcdcdc; \
-                color:#666666; \
                 font-size:15px; \
                 font-weight:bold; \
                 padding:8px 8px; \
             } \
         "
+        return stylesheet
 
     def _add_text_entry(self, row, left, right):
         left = QLabel(left + ":")

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -38,7 +38,7 @@ class InfoWidget(QWidget):
                 color:#666666; \
                 font-size:15px; \
                 font-weight:bold; \
-                padding:15px 15px; \
+                padding:8px 8px; \
             } \
         "
 

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -4,8 +4,15 @@
 
 import sys
 
-from PySide6.QtWidgets import (QGridLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget,
-                               QPushButton, QHBoxLayout)
+from PySide6.QtWidgets import (
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ..utils import interface_style
 

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -36,7 +36,7 @@ class InfoWidget(QWidget):
     def set_shortcuts(self):
         shortcuts = {
             "Open": "Ctrl+O",
-            "History": "Ctrl+H",
+            "History": "Ctrl+Y",
             "Quit": "Ctrl+Q",
         }
         self.set_values(shortcuts, shortcut=True)

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -21,6 +21,14 @@ class InfoWidget(QWidget):
         vbox.addLayout(self.grid)
         self.set_values(values)
 
+    def set_shortcuts(self):
+        shortcuts = {
+            "Open": "Ctrl+O",
+            "History": "Ctrl+H",
+            "Quit": "Ctrl+Q",
+        }
+        self.set_values(shortcuts, shortcut=True)
+
     def _get_shortcut_style(self):
         return " \
             .shortcut { \

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -100,9 +100,9 @@ class InfoWidget(QWidget):
             Whether the values describe shortcuts or not. Defaults to False.
         """
         self.clear()
+        self.layout().takeAt(1)  # remove vertical stretch
         if shortcut:
             self.grid.setColumnStretch(1, 0)
-            self.layout().takeAt(1)  # remove vertical stretch
         else:
             self.grid.setColumnStretch(1, 1)
             self.layout().addStretch(1)

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -74,6 +74,8 @@ class InfoWidget(QWidget):
         ----------
         values : dict
             Each key/value pair in this dict is displayed in a row separated by a colon.
+        shortcut : bool
+            Whether the values describe shortcuts or not. Defaults to False.
         """
         self.clear()
         if shortcut:


### PR DESCRIPTION
This PR populates the `InfoWidget` at init with the default shortcuts:

![image](https://user-images.githubusercontent.com/18143289/161098117-25e01280-17fe-4326-917a-31a4a1b8110e.png)

For now it reuses `set_values()` because it's the most convenient but to achieve something closer to the desired look of #312, something more elaborate is required.

Closes https://github.com/cbrnr/mnelab/issues/312