### PR TITLE
Fix XDF marker stream detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - name: Build wheel
-      run: pip wheel -w ~/.wheelhouse .
+      run: |
+        pip install wheel
+        pip wheel -w ~/.wheelhouse .
     - uses: actions/upload-artifact@v2
       with:
         path: ~/.wheelhouse/mnelab*.whl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - name: Build wheel
-      run: pip wheel -w ~/.wheelhouse .
+      run: |
+        pip install wheel
+        pip wheel -w ~/.wheelhouse .
     - uses: actions/upload-artifact@v2
       with:
         name: mnelab-wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Change the default cursor to a spinning wheel when the data is changed ([#341](https://github.com/cbrnr/mnelab/pull/341) by [Guillaume Favelier](https://github.com/GuillaumeFavelier))
 
+### Fixed
+- Fix XDF marker stream detection and loading ([#345](https://github.com/cbrnr/mnelab/pull/345) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [0.8.1] - 2022-03-29
 ### Fixed
 - Fix loading of application icon ([#339](https://github.com/cbrnr/mnelab/pull/339) by [Guillaume Favelier](https://github.com/GuillaumeFavelier))

--- a/mnelab/io/xdf.py
+++ b/mnelab/io/xdf.py
@@ -139,7 +139,8 @@ def read_raw_xdf(
     raw._filenames = [fname]
 
     for stream_id, stream in streams.items():
-        if not (stream["info"]["nominal_srate"] == ["0"] and stream["info"]["channel_format"] == ["string"]):  # noqa: E501
+        srate = float(stream["info"]["nominal_srate"][0])
+        if not (srate == 0 and stream["info"]["channel_format"] == ["string"]):
             continue
         onsets = stream["time_stamps"] - first_time
         prefix = f"{stream_id}-" if prefix_markers else ""


### PR DESCRIPTION
Some marker streams have not been detected correctly, because we switched the nominal sampling rate to `float`, but still compared everything with strings (i.e. `'0.00000' == '0'`). This PR fixes this comparison by comparing numbers instead of strings.