### PR TITLE
Fix XDF marker streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [UNRELEASED] - xxxx-xx-xx
+## [0.8.3] - 2022-04-21
+### Fixed
+- Fix XDF marker stream regression ([#346](https://github.com/cbrnr/mnelab/pull/346) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.8.2] - 2022-04-13
 ### Added

--- a/mnelab/__init__.py
+++ b/mnelab/__init__.py
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import QApplication
 from .mainwindow import MainWindow
 from .model import Model
 
-__version__ = "0.9.0.dev0"
+__version__ = "0.8.3"
 
 
 def main():

--- a/mnelab/io/xdf.py
+++ b/mnelab/io/xdf.py
@@ -138,9 +138,10 @@ def read_raw_xdf(
     raw = mne.io.RawArray(all_time_series_scaled, info)
     raw._filenames = [fname]
 
+    # convert marker streams to annotations
     for stream_id, stream in streams.items():
         srate = float(stream["info"]["nominal_srate"][0])
-        if not (srate == 0 and stream["info"]["channel_format"] == ["string"]):
+        if srate != 0:  # marker streams with regular srate are not supported yet
             continue
         onsets = stream["time_stamps"] - first_time
         prefix = f"{stream_id}-" if prefix_markers else ""


### PR DESCRIPTION
This now only requires marker streams to have a sampling rate different from zero. This means that regularly sampled marker streams are currently not supported, but unless these are of type string they will be regular channels anyway. Regularly sampled string channels do not work yet (and never have previously).