### PR TITLE
Enable importing 1D arrays from .mat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - XXXX-XX-XX
+### Added
+- Support importing 1D arrays from .mat files ([#348](https://github.com/cbrnr/mnelab/pull/348) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.8.3] - 2022-04-21
 ### Fixed

--- a/mnelab/io/mat.py
+++ b/mnelab/io/mat.py
@@ -2,6 +2,7 @@ import re
 
 from mne import create_info
 from mne.io import RawArray
+from numpy import atleast_2d
 from scipy.io import loadmat
 
 
@@ -21,7 +22,7 @@ def read_raw_mat(fname, variable, fs, transpose=False, *args, **kwargs):
         Whether to transpose the data.
     """
     mat = loadmat(fname, simplify_cells=True)
-    data = _get_dict_value(mat, variable.split("."))
+    data = atleast_2d(_get_dict_value(mat, variable.split(".")))
     if transpose:
         data = data.T
     info = create_info(data.shape[0], fs, "eeg")


### PR DESCRIPTION
This adds the possibility to import 1D numeric arrays from .mat files. Therefore, arrays must be 1D or 2D and their dtypes must be either float or double. Fixes #347.