### PR TITLE
Restrict XDF markers to one channel

### DIFF
--- a/mnelab/io/xdf.py
+++ b/mnelab/io/xdf.py
@@ -141,7 +141,9 @@ def read_raw_xdf(
     # convert marker streams to annotations
     for stream_id, stream in streams.items():
         srate = float(stream["info"]["nominal_srate"][0])
-        if srate != 0:  # marker streams with regular srate are not supported yet
+        n_chans = int(stream["info"]["channel_count"][0])
+        # marker streams with regular srate or more than 1 channel are not supported yet
+        if srate != 0 or n_chans > 1:
             continue
         onsets = stream["time_stamps"] - first_time
         prefix = f"{stream_id}-" if prefix_markers else ""


### PR DESCRIPTION
The previous change related to importing XDF marker streams turned out to be too liberal. It required only a sampling rate of 0 Hz, but there are 0 Hz streams with multiple channels, which are problematic right now.

Therefore, this change defines marker streams that can be imported as annotations as follows:

- Irregular sampling rate (i.e. 0 Hz)
- Just one channel

The data type is irrelevant, so we can still import numeric markers as long as these two criteria are met.