### PR TITLE
Show shortcuts when no file is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - xxxx-xx-xx
+### Added
+- Show some keyboard shortcuts when no file is open ([#350](https://github.com/cbrnr/mnelab/pull/350) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.8.4] - 2022-05-05
 ### Added

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 from contextlib import contextmanager
 from functools import partial
+from operator import itemgetter
 from pathlib import Path
 from sys import version_info
 
@@ -278,7 +279,11 @@ class MainWindow(QMainWindow):
         )
 
         view_menu = self.menuBar().addMenu("&View")
-        self.actions["history"] = view_menu.addAction("&History", self.show_history)
+        self.actions["history"] = view_menu.addAction(
+            "&History",
+            self.show_history,
+            QKeySequence(Qt.CTRL | Qt.Key_Y),
+        )
         self.actions["toolbar"] = view_menu.addAction("&Toolbar", self._toggle_toolbar)
         self.actions["toolbar"].setCheckable(True)
         self.actions["statusbar"] = view_menu.addAction("&Statusbar",
@@ -340,7 +345,8 @@ class MainWindow(QMainWindow):
 
         self.infowidget = QStackedWidget()
         self.infowidget.addWidget(InfoWidget())
-        self.infowidget.addWidget(EmptyWidget())
+        emptywidget = EmptyWidget(itemgetter("open_file", "history")(self.actions))
+        self.infowidget.addWidget(emptywidget)
         splitter.addWidget(self.infowidget)
         width = splitter.size().width()
         splitter.setSizes((int(width * 0.3), int(width * 0.7)))

--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import (
     QMainWindow,
     QMessageBox,
     QSplitter,
+    QStackedWidget,
 )
 from pyxdf import resolve_streams
 
@@ -42,7 +43,7 @@ from .viz import (
     plot_evoked_comparison,
     plot_evoked_topomaps,
 )
-from .widgets import InfoWidget
+from .widgets import EmptyWidget, InfoWidget
 
 
 class MainWindow(QMainWindow):
@@ -337,7 +338,9 @@ class MainWindow(QMainWindow):
         splitter = QSplitter()
         splitter.addWidget(self.sidebar)
 
-        self.infowidget = InfoWidget()
+        self.infowidget = QStackedWidget()
+        self.infowidget.addWidget(InfoWidget())
+        self.infowidget.addWidget(EmptyWidget())
         splitter.addWidget(self.infowidget)
         width = splitter.size().width()
         splitter.setSizes((int(width * 0.3), int(width * 0.7)))
@@ -415,9 +418,10 @@ class MainWindow(QMainWindow):
 
         # update info widget
         if self.model.data:
-            self.infowidget.set_values(self.model.get_info())
+            self.infowidget.setCurrentIndex(0)
+            self.infowidget.widget(0).set_values(self.model.get_info())
         else:
-            self.infowidget.clear()
+            self.infowidget.setCurrentIndex(1)
 
         # update status bar
         if self.model.data:

--- a/mnelab/widgets/__init__.py
+++ b/mnelab/widgets/__init__.py
@@ -2,4 +2,4 @@
 #
 # License: BSD (3-clause)
 
-from .infowidget import InfoWidget
+from .infowidget import EmptyWidget, InfoWidget

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -5,6 +5,39 @@
 from PySide6.QtWidgets import QGridLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget
 
 
+def _make_shortcuts_table(names, shortcuts, style="light"):
+    text_color = "#777"
+    background_color = "#fff" if style == "light" else "#000"
+    html = f"""<!DOCTYPE html>
+    <html>
+      <head>
+        <style>
+          html {{ font-size: 16px; }}
+          kbd {{
+            background-color: {background_color};
+            font-weight: 600;
+            color: {text_color};
+          }}
+          table {{ color: {text_color}; }}
+        </style>
+      </head>
+      <body>
+        <table>
+          <tbody>"""
+    for name, shortcut in zip(names, shortcuts):
+        modifier, key = shortcut
+        html += (
+            f'\n            <tr><td align="right" width="50%">{name} </td>'
+            f'<td><kbd>{modifier}</kbd> '
+            f'<kbd>{key}</kbd></td></tr>'
+        )
+    html += """\n          </tbody>
+        </table>
+      </body>
+    </html>"""
+    return html
+
+
 class InfoWidget(QWidget):
     """Display basic file information in a table (two columns).
 
@@ -46,3 +79,14 @@ class InfoWidget(QWidget):
             item.widget().deleteLater()
             del item
             item = self.grid.takeAt(0)
+
+
+class EmptyWidget(QWidget):
+    def __init__(self):
+        super().__init__()
+        shortcuts = _make_shortcuts_table(["Open", "Close", "History"], ["⌘O", "⌘W", "⌘Y"])
+        text = QLabel(shortcuts)
+        vbox = QVBoxLayout(self)
+        vbox.addStretch()
+        vbox.addWidget(text)
+        vbox.addStretch()

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -26,7 +26,7 @@ def _make_shortcuts_table(actions):
     for action in actions:
         name = action.text().replace("&", "").replace(".", "")
         shortcut = action.shortcut().toString(format=QKeySequence.NativeText)
-        modifier, key = shortcut
+        modifier, key = shortcut[:-1].strip().replace("+", ""), shortcut[-1]
         html += (
             f'\n            <tr><td align="right" width="50%">{name} </td>'
             f'<td><kbd>{modifier}</kbd> '

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -26,12 +26,15 @@ def _make_shortcuts_table(actions):
     for action in actions:
         name = action.text().replace("&", "").replace(".", "")
         shortcut = action.shortcut().toString(format=QKeySequence.NativeText)
-        modifier, key = shortcut[:-1].strip().replace("+", ""), shortcut[-1]
+        modifier, key = shortcut[:-1].strip(), shortcut[-1]
         html += (
             f'\n            <tr><td align="right" width="50%">{name} </td>'
-            f'<td><kbd>{modifier}</kbd> '
-            f'<kbd>{key}</kbd></td></tr>'
         )
+        if modifier[-1] == "+":
+            html += f'<td><kbd>{modifier[:-1]}</kbd>+'
+        else:
+            html += f'<td><kbd>{modifier}</kbd> '
+        html += f'<kbd>{key}</kbd></td></tr>'
     html += """\n          </tbody>
         </table>
       </body>

--- a/mnelab/widgets/infowidget.py
+++ b/mnelab/widgets/infowidget.py
@@ -2,19 +2,18 @@
 #
 # License: BSD (3-clause)
 
+from PySide6.QtGui import QKeySequence
 from PySide6.QtWidgets import QGridLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget
 
 
-def _make_shortcuts_table(names, shortcuts, style="light"):
+def _make_shortcuts_table(actions):
     text_color = "#777"
-    background_color = "#fff" if style == "light" else "#000"
     html = f"""<!DOCTYPE html>
     <html>
       <head>
         <style>
           html {{ font-size: 16px; }}
           kbd {{
-            background-color: {background_color};
             font-weight: 600;
             color: {text_color};
           }}
@@ -24,7 +23,9 @@ def _make_shortcuts_table(names, shortcuts, style="light"):
       <body>
         <table>
           <tbody>"""
-    for name, shortcut in zip(names, shortcuts):
+    for action in actions:
+        name = action.text().replace("&", "").replace(".", "")
+        shortcut = action.shortcut().toString(format=QKeySequence.NativeText)
         modifier, key = shortcut
         html += (
             f'\n            <tr><td align="right" width="50%">{name} </td>'
@@ -82,10 +83,9 @@ class InfoWidget(QWidget):
 
 
 class EmptyWidget(QWidget):
-    def __init__(self):
+    def __init__(self, actions):
         super().__init__()
-        shortcuts = _make_shortcuts_table(["Open", "Close", "History"], ["⌘O", "⌘W", "⌘Y"])
-        text = QLabel(shortcuts)
+        text = QLabel(_make_shortcuts_table(actions))
         vbox = QVBoxLayout(self)
         vbox.addStretch()
         vbox.addWidget(text)


### PR DESCRIPTION
Supersedes #343 with a simpler approach using a `QStackedWidget`.
Closes #312.

To Do:
- [x] ~~Support dark and light mode~~ (not necessary, we just use the same text color)
- [x] ~~Display always enabled actions with shortcuts~~ (it's better to manually specify the actions that should be displayed)
- [x] Use Ctrl or ⌘ (depending on platform)
- [x] Add ⌘Y as History shortcut