### PR TITLE
Set python-version for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - uses: pre-commit/action@v3.0.0
 
   build-wheel:
@@ -20,6 +22,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: Build wheel
       run: |
         pip install wheel
@@ -35,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: '3.10'
       - name: Build sdist
         run: |
           pip install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - uses: pre-commit/action@v3.0.0
 
   build-wheel:
@@ -21,6 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: Build wheel
       run: |
         pip install wheel
@@ -34,7 +38,7 @@ jobs:
     needs: build-wheel
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ['3.8', '3.9', '3.10']
     name: Run tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
For jobs like style and build-wheel, this PR now sets the Python version to the latest supported version (3.10 currently).