### PR TITLE
Improve unsupported file type error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Show some keyboard shortcuts when no file is open ([#350](https://github.com/cbrnr/mnelab/pull/350) by [Clemens Brunner](https://github.com/cbrnr))
 - Always show a notification when running the dev version ([#351](https://github.com/cbrnr/mnelab/pull/351) by [Clemens Brunner](https://github.com/cbrnr))
 
+### Fixed
+- Helpful error message when opening an unsupported file type ([#360](https://github.com/cbrnr/mnelab/pull/360) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [0.8.4] - 2022-05-05
 ### Added
 - Support importing 1D arrays from .mat files ([#348](https://github.com/cbrnr/mnelab/pull/348) by [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/io/readers.py
+++ b/mnelab/io/readers.py
@@ -56,6 +56,7 @@ def split_name_ext(fname):
         ext = "".join(suffixes[i:]).lower()
         if ext in readers.keys():
             return Path(fname).name[:-len(ext)], ext
+    return fname, None  # unknown file extension
 
 
 def read_raw(fname, *args, **kwargs):
@@ -79,6 +80,9 @@ def read_raw(fname, *args, **kwargs):
     _, ext = split_name_ext(fname)
     if ext is not None:
         return readers[ext](fname, *args, **kwargs)
-    raise ValueError(f"Unknown file type {''.join(Path(fname).suffixes)}).")
+    else:
+        ext = "".join(Path(fname).suffixes)
+        msg = f"Unsupported file type ({ext})." if ext else "Unsupported file type."
+        raise ValueError(msg)
     # here we could inspect the file signature to determine its type, which would allow us
     # to read file independently of their extensions

--- a/mnelab/test/test_readers.py
+++ b/mnelab/test/test_readers.py
@@ -10,4 +10,4 @@ def test_split_name_ext(ext):
 
 
 def test_split_name_ext_unsupported():
-    assert split_name_ext("test.xxx") is None
+    assert split_name_ext("test.xxx") == ("test.xxx", None)


### PR DESCRIPTION
Previously, trying to open an unsupported file type resulted in a cryptic error message ("TypeError: cannot unpack non-iterable NoneType object"). This PR changes it to a helpful message ("Unsupported file type.").