### PR TITLE
Limit PySide6 minor version to 6.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     mne>=1.0.0
-    PySide6>=6.2.0
+    PySide6>=6.2.0,<6.4.0
     numpy>=1.20.0
     scipy>=1.7.0
     matplotlib>=3.5.0


### PR DESCRIPTION
Resolves #362.