### PR TITLE
Support more microvolt units in XDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Added
+- Support more microvolt unit abbreviations in XDF import ([#365](https://github.com/cbrnr/mnelab/pull/365) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.8.5] - 2022-10-08
 ### Added

--- a/mnelab/io/xdf.py
+++ b/mnelab/io/xdf.py
@@ -132,7 +132,8 @@ def read_raw_xdf(
 
     info = mne.create_info(ch_names=labels_all, sfreq=fs, ch_types=types_all)
 
-    scale = np.array([1e-6 if u in ("microvolt", "microvolts") else 1 for u in units_all])
+    microvolts = ("microvolt", "microvolts", "µV", "μV", "uV")
+    scale = np.array([1e-6 if u in microvolts else 1 for u in units_all])
     all_time_series_scaled = (all_time_series * scale).T
 
     raw = mne.io.RawArray(all_time_series_scaled, info)


### PR DESCRIPTION
This PR adds "µV", "μV", and "uV" to the list of supported units (previously, only "microvolt" and "microvolts" were supported).