### PR TITLE
Correctly scale data when exporting to BV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Fixed
+- Correctly scale data when exporting to BrainVision ([#376](https://github.com/cbrnr/mnelab/pull/376) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.8.6] - 2023-04-05
 ### Added

--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -145,7 +145,7 @@ def write_bv(fname, raw, events=None):
         fname_base=name,
         folder_out=parent,
         events=events,
-        unit=units
+        unit=units,
     )
 
 

--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -136,6 +136,8 @@ def write_bv(fname, raw, events=None):
             events = np.column_stack([events[:, [0, 2]], dur.astype(int)])
     else:
         events = events[:, [0, 2]]
+    units = [ch["unit"] for ch in raw.info["chs"]]
+    units = ["V" if unit == 107 else "AU" for unit in units]
     pybv.write_brainvision(
         data=data,
         sfreq=fs,
@@ -143,6 +145,7 @@ def write_bv(fname, raw, events=None):
         fname_base=name,
         folder_out=parent,
         events=events,
+        unit=units
     )
 
 


### PR DESCRIPTION
This fixes a bug where EEG channels, which are represented in V internally, get scaled incorrectly when exporting to BrainVision.