### PR TITLE
Fix RTD by upgrading to latest image

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,10 +4,14 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: doc/source/conf.py
 
 python:
-  version: "3.8"
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
This fixes a version conflict, which prevented the docs from building.