### PR TITLE
Export to BV in µV

### DIFF
--- a/mnelab/io/writers.py
+++ b/mnelab/io/writers.py
@@ -137,7 +137,7 @@ def write_bv(fname, raw, events=None):
     else:
         events = events[:, [0, 2]]
     units = [ch["unit"] for ch in raw.info["chs"]]
-    units = ["V" if unit == 107 else "AU" for unit in units]
+    units = ["µV" if unit == 107 else "AU" for unit in units]
     pybv.write_brainvision(
         data=data,
         sfreq=fs,


### PR DESCRIPTION
Exporting in µV increases compatibility with BrainVision Analyzer (which can handle V, but the default zoom level is not appropriate).