### PR TITLE
Select marker streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 - Add automatic light/dark theme switching on Windows ([#398](https://github.com/cbrnr/mnelab/pull/398) by [Clemens Brunner](https://github.com/cbrnr))
 - Add support for importing .npy files ([#213](https://github.com/cbrnr/mnelab/pull/213) by [jgcaffari1](https://github.com/jgcaffari1) and [Clemens Brunner](https://github.com/cbrnr))
+- Add ability to import selected XDF marker streams (previously, all marker streams were imported) ([#395](https://github.com/cbrnr/mnelab/pull/395) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Removed
 - Remove support for Python 3.8 ([#396](https://github.com/cbrnr/mnelab/pull/396) by [Clemens Brunner](https://github.com/cbrnr))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Added
 - Add automatic light/dark theme switching on Windows ([#398](https://github.com/cbrnr/mnelab/pull/398) by [Clemens Brunner](https://github.com/cbrnr))
 - Add support for importing .npy files ([#213](https://github.com/cbrnr/mnelab/pull/213) by [jgcaffari1](https://github.com/jgcaffari1) and [Clemens Brunner](https://github.com/cbrnr))
-- Add ability to import selected XDF marker streams (previously, all marker streams were imported) ([#395](https://github.com/cbrnr/mnelab/pull/395) by [Clemens Brunner](https://github.com/cbrnr))
+- Add ability to import selected XDF marker streams (previously, all marker streams were automatically imported) ([#395](https://github.com/cbrnr/mnelab/pull/395) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Removed
 - Remove support for Python 3.8 ([#396](https://github.com/cbrnr/mnelab/pull/396) by [Clemens Brunner](https://github.com/cbrnr))

--- a/mnelab/io/xdf.py
+++ b/mnelab/io/xdf.py
@@ -84,8 +84,8 @@ def read_raw_xdf(
         IDs of streams to load. A list of available streams can be obtained with
         `pyxdf.resolve_streams(fname)`.
     marker_ids : list[int] | None
-        IDs of marker streams to load. If None, load all marker streams. A marker stream is
-        a stream with a nominal sampling frequency of 0 Hz.
+        IDs of marker streams to load. If `None`, load all marker streams. A marker stream
+        is a stream with a nominal sampling frequency of 0 Hz.
     prefix_markers : bool
         Whether or not to prefix marker streams with their corresponding stream ID.
     fs_new : float | None

--- a/mnelab/io/xdf.py
+++ b/mnelab/io/xdf.py
@@ -93,7 +93,7 @@ def read_raw_xdf(
         XDF file data.
     """
     if len(stream_ids) > 1 and fs_new is None:
-        raise ValueError("Parameter 'fs_new' required when reading multiple streams.")
+        raise ValueError("Argument `fs_new` required when reading multiple streams.")
 
     streams, _ = load_xdf(fname)
     streams = {stream["info"]["stream_id"]: stream for stream in streams}


### PR DESCRIPTION
This PR adds the option to select a subset of marker streams. The previous behavior was to load all marker streams, which remains the default. However, a subset can now be selected by passing a list of marker stream IDs as the `marker_ids` argument.