### PR TITLE
Remove `AA_UseHighDpiPixmaps` setting

### DIFF
--- a/mnelab/__init__.py
+++ b/mnelab/__init__.py
@@ -40,7 +40,6 @@ def main():
         app.setWindowIcon(QIcon(f"{Path(__file__).parent}/icons/mnelab-logo.svg"))
     if sys.platform.startswith("win"):
         app.setStyle("fusion")
-    app.setAttribute(Qt.ApplicationAttribute.AA_UseHighDpiPixmaps)
     model = Model()
     model.view = MainWindow(model)
     if len(sys.argv) > 1:  # open files from command line arguments


### PR DESCRIPTION
This setting is deprecated, high DPI icons are now used by default.