### PR TITLE
Set MNE browser backend to Matplotlib

### DIFF
--- a/mnelab/mainwindow.py
+++ b/mnelab/mainwindow.py
@@ -78,6 +78,9 @@ class MainWindow(QMainWindow):
         # trigger theme setting
         self.event(QEvent(QEvent.PaletteChange))
 
+        # set MNE browser backend to Matplotlib
+        mne.viz.set_browser_backend("matplotlib")
+
         self.actions = {}  # contains all actions
 
         # initialize menus


### PR DESCRIPTION
Due to issues with mne-qt-browser messing up icon paths, I'm forcing the Matplotlib backend for now.