### PR TITLE
Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include CHANGELOG.md
-include CONTRIBUTING.md
-include mnelab.png
-recursive-include mnelab/images *
-recursive-include mnelab/icons *


### PR DESCRIPTION
This file is only needed when using `setuptools` as a build backend. Since we've switched to `hatchling`, we can safely remove it.