### PR TITLE
Manually trigger `PaletteChange`

### DIFF
--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -14,7 +14,7 @@ from sys import version_info
 import mne
 import numpy as np
 from mne import channel_type
-from PySide6.QtCore import QEvent, QMetaObject, QModelIndex, QObject, Qt, QUrl, Signal, Slot
+from PySide6.QtCore import QEvent, QMetaObject, QModelIndex, QObject, Qt, QUrl, Slot
 from PySide6.QtGui import QAction, QDesktopServices, QIcon, QKeySequence
 from PySide6.QtWidgets import (
     QApplication,

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -14,7 +14,7 @@ from sys import version_info
 import mne
 import numpy as np
 from mne import channel_type
-from PySide6.QtCore import QEvent, QMetaObject, QModelIndex, QObject, Qt, QUrl, Slot
+from PySide6.QtCore import QEvent, QMetaObject, QModelIndex, QObject, Qt, QUrl, Signal, Slot
 from PySide6.QtGui import QAction, QDesktopServices, QIcon, QKeySequence
 from PySide6.QtWidgets import (
     QApplication,
@@ -92,6 +92,7 @@ class MainWindow(QMainWindow):
             [f"{Path(__file__).parent}/icons"] + QIcon.themeSearchPaths()
         )
         QIcon.setFallbackThemeName("light")
+        QApplication.sendEvent(self, QEvent(QEvent.PaletteChange))
 
         self.actions = {}  # contains all actions
 


### PR DESCRIPTION
The icon theme is only set when the `PaletteChange` event is emitted, so we need to do this manually on init (otherwise, the default light icon theme will be used even in dark mode).