### PR TITLE
Replace pyedflib with edfio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Changed
+- Add [edfio](https://edfio.readthedocs.io/en/stable/index.html) as core dependency and replace pyedflib, which means that EDF export is now supported out of the box ([#425](https://github.com/cbrnr/mnelab/pull/425) by [Clemens Brunner](https://github.com/cbrnr))
+
+### Removed
+- Remove support for exporting to BDF ([#425](https://github.com/cbrnr/mnelab/pull/425) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.9.1] - 2024-05-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ python -m mnelab
 MNELAB requires Python ≥ 3.9 and the following packages:
 - [mne](https://mne.tools/stable/index.html) ≥ 1.7.0
 - [PySide6](https://www.qt.io/qt-for-python) ≥ 6.7.1
+- [edfio](https://edfio.readthedocs.io/en/stable/index.html) ≥ 0.4.2
+- [matplotlib](https://matplotlib.org/) ≥ 3.8.0
 - [numpy](http://www.numpy.org/) ≥ 1.25.0
 - [scipy](https://scipy.org/) ≥ 1.10.0
-- [matplotlib](https://matplotlib.org/) ≥ 3.8.0
 - [pyxdf](https://github.com/xdf-modules/xdf-Python) ≥ 1.16.4
 - [pyobjc-framework-Cocoa](https://pyobjc.readthedocs.io/en/latest/) ≥ 10.0 (macOS only)
 
 Optional dependencies provide additional features:
-- [scikit-learn](https://scikit-learn.org/stable/) ≥ 1.3.0 (ICA computation with FastICA)
-- [python-picard](https://pierreablin.github.io/picard/) ≥ 0.7.0 (ICA computation with PICARD)
-- [pyEDFlib](https://pyedflib.readthedocs.io/en/latest/) ≥ 0.1.35 (EDF/BDF export)
-- [pybv](https://pybv.readthedocs.io/en/stable/) ≥ 0.7.4 (BrainVision VHDR/VMRK/EEG export)
 - [mne-qt-browser](https://github.com/mne-tools/mne-qt-browser) ≥ 0.6.2 (alternative raw plot backend)
+- [pybv](https://pybv.readthedocs.io/en/stable/) ≥ 0.7.4 (BrainVision VHDR/VMRK/EEG export)
+- [python-picard](https://pierreablin.github.io/picard/) ≥ 0.7.0 (ICA computation with PICARD)
+- [scikit-learn](https://scikit-learn.org/stable/) ≥ 1.3.0 (ICA computation with FastICA)
 
 
 ### Contributing

--- a/docs/source/tutorial/index.md
+++ b/docs/source/tutorial/index.md
@@ -5,18 +5,18 @@
 MNELAB requires Python ≥ 3.9 and the following packages:
 - [mne](https://mne.tools/stable/index.html) ≥ 1.7.0
 - [PySide6](https://www.qt.io/qt-for-python) ≥ 6.7.1
+- [edfio](https://edfio.readthedocs.io/en/stable/index.html) ≥ 0.4.2
+- [matplotlib](https://matplotlib.org/) ≥ 3.8.0
 - [numpy](http://www.numpy.org/) ≥ 1.25.0
 - [scipy](https://scipy.org/) ≥ 1.10.0
-- [matplotlib](https://matplotlib.org/) ≥ 3.8.0
 - [pyxdf](https://github.com/xdf-modules/xdf-Python) ≥ 1.16.4
 - [pyobjc-framework-Cocoa](https://pyobjc.readthedocs.io/en/latest/) ≥ 10.0 (macOS only)
 
 Optional dependencies provide additional features:
-- [scikit-learn](https://scikit-learn.org/stable/) ≥ 1.3.0 (ICA computation with FastICA)
-- [python-picard](https://pierreablin.github.io/picard/) ≥ 0.7.0 (ICA computation with PICARD)
-- [pyEDFlib](https://pyedflib.readthedocs.io/en/latest/) ≥ 0.1.35 (EDF/BDF export)
-- [pybv](https://pybv.readthedocs.io/en/stable/) ≥ 0.7.4 (BrainVision VHDR/VMRK/EEG export)
 - [mne-qt-browser](https://github.com/mne-tools/mne-qt-browser) ≥ 0.6.2 (alternative raw plot backend)
+- [pybv](https://pybv.readthedocs.io/en/stable/) ≥ 0.7.4 (BrainVision VHDR/VMRK/EEG export)
+- [python-picard](https://pierreablin.github.io/picard/) ≥ 0.7.0 (ICA computation with PICARD)
+- [scikit-learn](https://scikit-learn.org/stable/) ≥ 1.3.0 (ICA computation with FastICA)
 
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ keywords = ["EEG", "MEG", "MNE", "GUI", "electrophysiology"]
 dependencies = [
     "mne >= 1.7.0",
     "PySide6 >= 6.7.1",
+    "edfio >= 0.4.2",
+    "matplotlib >= 3.8.0",
     "numpy >= 1.25.0",
     "scipy >= 1.10.0",
-    "matplotlib >= 3.8.0",
     "pyxdf >= 1.16.4",
     "pyobjc-framework-Cocoa >= 10.0; platform_system=='Darwin'",
 ]
@@ -34,11 +35,10 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 full = [
-    "scikit-learn >= 1.3.0",  # fastica
-    "python-picard >= 0.7.0",  # picard
-    "pyEDFlib >= 0.1.35",  # edf
-    "pybv >= 0.7.4",  # brainvision
     "mne-qt-browser >= 0.6.2",  # alternative browser backend
+    "pybv >= 0.7.4",  # brainvision
+    "python-picard >= 0.7.0",  # picard
+    "scikit-learn >= 1.3.0",  # fastica
 ]
 dev = [
     "mnelab[full]",

--- a/src/mnelab/io/writers.py
+++ b/src/mnelab/io/writers.py
@@ -55,69 +55,8 @@ def write_set(fname, raw):
 
 
 def write_edf(fname, raw):
-    """Export raw to EDF/BDF file (requires pyEDFlib)."""
-    import pyedflib
-
-    suffixes = Path(fname).suffixes
-    ext = "".join(suffixes[-1:])
-    if ext == ".edf":
-        filetype = pyedflib.FILETYPE_EDFPLUS
-        dmin, dmax = -32768, 32767
-    elif ext == ".bdf":
-        filetype = pyedflib.FILETYPE_BDFPLUS
-        dmin, dmax = -8388608, 8388607
-
-    data = raw.get_data()
-    fs = raw.info["sfreq"]
-    nchan = raw.info["nchan"]
-    ch_names = raw.info["ch_names"]
-    meas_date = raw.info["meas_date"]
-    hp, lp = raw.info["highpass"], raw.info["lowpass"]
-    hp = "DC" if hp == 0 else f"{hp:.0f} Hz"
-    lp = f"{lp:.0f} Hz"
-    f = pyedflib.EdfWriter(fname, nchan, filetype)
-    channel_info = []
-    data_list = []
-    for i, kind in enumerate(raw.get_channel_types()):
-        if kind == "eeg":
-            data[i] *= 1e6  # convert to microvolts
-            dimension = "uV"
-            prefilter = f"HP: {hp}; LP: {lp}"
-            pmin, pmax = int(data[i].min()), int(data[i].max())
-            transducer = "Electrode"
-        elif kind == "stim":
-            dimension = "Boolean"
-            prefilter = "No filtering"
-            pmin, pmax = dmin, dmax
-            transducer = "Triggers and status"
-        else:
-            raise NotImplementedError(
-                f"Channel type {kind} not supported (currently only EEG and STIM channels "
-                f"work)"
-            )
-        channel_info.append(
-            dict(
-                label=ch_names[i],
-                dimension=dimension,
-                sample_rate=fs,
-                physical_min=pmin,
-                physical_max=pmax,
-                digital_min=dmin,
-                digital_max=dmax,
-                transducer=transducer,
-                prefilter=prefilter,
-            )
-        )
-        data_list.append(data[i])
-    f.setTechnician("MNELAB")
-    f.setSignalHeaders(channel_info)
-    if raw.info["meas_date"] is not None:
-        f.setStartdatetime(meas_date)
-    # note that currently, only blocks of whole seconds can be written
-    f.writeSamples(data_list)
-    for annot in raw.annotations:
-        f.writeAnnotation(annot["onset"], annot["duration"], annot["description"])
-    f.close()
+    """Export raw to EDF file."""
+    raw.export(fname)
 
 
 def write_bv(fname, raw, events=None):
@@ -153,19 +92,13 @@ def write_bv(fname, raw, events=None):
 # list with three elements: (1) the writer function, (2) the full file format name, and (3)
 # a (comma-separated) string indicating the supported objects
 writers = {
+    ".edf": [write_edf, "European Data Format", "raw"],
     ".fif": [write_fif, "Elekta Neuromag", "raw,epoch"],
     ".fif.gz": [write_fif, "Elekta Neuromag", "raw,epoch"],
     ".set": [write_set, "EEGLAB", "raw"],
 }
 if have["pybv"]:
     writers.update({".eeg": [write_bv, "BrainVision", "raw"]})
-if have["pyedflib"]:
-    writers.update(
-        {
-            ".edf": [write_edf, "European Data Format", "raw"],
-            ".bdf": [write_edf, "Biosemi Data Format", "raw"],
-        }
-    )
 
 
 def write_raw(fname, raw):

--- a/src/mnelab/utils/dependencies.py
+++ b/src/mnelab/utils/dependencies.py
@@ -4,8 +4,8 @@
 
 from importlib import import_module
 
-required = ["mne", "numpy", "scipy", "matplotlib", "PySide6", "pyxdf"]
-optional = ["sklearn", "picard", "pyedflib", "pybv", "mne-qt-browser"]
+required = ["mne", "PySide6", "edfio", "matplotlib", "numpy", "pyxdf", "scipy"]
+optional = ["mne-qt-browser", "picard", "pybv", "sklearn"]
 
 have = {}
 for package in required + optional:


### PR DESCRIPTION
In addition to just replacing pyedflib with edfio, this PR promotes edfio to a core dependency. The main rationale behind this decision is that edfio is pure Python, whereas pyedflib relies on a C library.

There is a drawback: it is now not possible to export to BDF. However, I think this is not a big deal, because BDF is a niche format, and users should prefer EDF in almost all cases.