### PR TITLE
Refactor readers to subclass `BaseRaw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Add [edfio](https://edfio.readthedocs.io/en/stable/index.html) as core dependency and replace pyedflib, which means that EDF export is now supported out of the box ([#425](https://github.com/cbrnr/mnelab/pull/425) by [Clemens Brunner](https://github.com/cbrnr))
 - Add pybv to required dependencies ([#429](https://github.com/cbrnr/mnelab/pull/429) by [Dennis Wambacher](https://github.com/d3njo))
+- Refactor readers to subclass `BaseRaw` ([#434](https://github.com/cbrnr/mnelab/pull/434) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Removed
 - Remove support for exporting to BDF ([#425](https://github.com/cbrnr/mnelab/pull/425) by [Clemens Brunner](https://github.com/cbrnr))

--- a/src/mnelab/io/mat.py
+++ b/src/mnelab/io/mat.py
@@ -6,10 +6,10 @@ from numpy import atleast_2d
 from scipy.io import loadmat
 
 
-class RawMat(BaseRaw):
+class RawMAT(BaseRaw):
     """Raw data from .mat file."""
 
-    def __init__(self, fname, variable, fs, transpose=False, *args, **kwargs):
+    def __init__(self, fname, variable, fs, transpose=False):
         """Read raw data from .mat file.
 
         Parameters
@@ -53,10 +53,10 @@ def read_raw_mat(fname, variable, fs, transpose=False, *args, **kwargs):
 
     Returns
     -------
-    RawMat
+    RawMAT
         The raw data.
     """
-    return RawMat(fname, variable, fs, transpose)
+    return RawMAT(fname, variable, fs, transpose)
 
 
 def parse_mat(fname):

--- a/src/mnelab/io/mat.py
+++ b/src/mnelab/io/mat.py
@@ -1,13 +1,41 @@
 import re
 
 from mne import create_info
-from mne.io import RawArray
+from mne.io import BaseRaw
 from numpy import atleast_2d
 from scipy.io import loadmat
 
 
+class RawMat(BaseRaw):
+    """Raw data from .mat file."""
+
+    def __init__(self, fname, variable, fs, transpose=False, *args, **kwargs):
+        """Read raw data from .mat file.
+
+        Parameters
+        ----------
+        fname : str
+            File name to load.
+        variable : str
+            Name of the variable to use. If nested within a struct, separate all names with
+            dots. For example, `y.X` corresponds to a variable `X` contained in a struct
+            `y`. If the cell array has multiple items, use `y.[0].X` to access the first
+            item named `X`, `y.[1].X` to access the second item named `X`, and so on.
+        fs : float
+            Sampling frequency (in Hz).
+        transpose : bool
+            Whether to transpose the data, the data should be of shape (channels, samples).
+        """
+        mat = loadmat(fname, simplify_cells=True)
+        data = atleast_2d(_get_dict_value(mat, variable.split(".")))
+        if transpose:
+            data = data.T
+        info = create_info(data.shape[0], fs, "eeg")
+        super().__init__(preload=data, info=info, filenames=[fname])
+
+
 def read_raw_mat(fname, variable, fs, transpose=False, *args, **kwargs):
-    """Read raw data from MAT file.
+    """Read raw data from .mat file.
 
     Parameters
     ----------
@@ -15,20 +43,20 @@ def read_raw_mat(fname, variable, fs, transpose=False, *args, **kwargs):
         File name to load.
     variable : str
         Name of the variable to use. If nested within a struct, separate all names with
-        dots. For example, "y.X" corresponds to a variable "X" contained in a struct "y".
+        dots. For example, `y.X` corresponds to a variable `X` contained in a struct `y`. If
+        the cell array has multiple items, use `y.[0].X` to access the first item named `X`,
+        `y.[1].X` to access the second item named `X`, and so on.
     fs : float
         Sampling frequency (in Hz).
     transpose : bool
-        Whether to transpose the data.
+        Whether to transpose the data, the data should be of shape (channels, samples).
+
+    Returns
+    -------
+    RawMat
+        The raw data.
     """
-    mat = loadmat(fname, simplify_cells=True)
-    data = atleast_2d(_get_dict_value(mat, variable.split(".")))
-    if transpose:
-        data = data.T
-    info = create_info(data.shape[0], fs, "eeg")
-    raw = RawArray(data, info)
-    raw._filenames = [fname]
-    return raw
+    return RawMat(fname, variable, fs, transpose)
 
 
 def parse_mat(fname):

--- a/src/mnelab/io/npy.py
+++ b/src/mnelab/io/npy.py
@@ -3,10 +3,10 @@ import numpy as np
 from mne.io import BaseRaw
 
 
-class RawNpy(BaseRaw):
+class RawNPY(BaseRaw):
     """Raw data from .npy file."""
 
-    def __init__(self, fname, fs, transpose=False, *args, **kwargs):
+    def __init__(self, fname, fs, transpose=False):
         """Read raw data from .npy file.
 
         Parameters
@@ -41,10 +41,10 @@ def read_raw_npy(fname, fs, transpose=False, *args, **kwargs):
 
     Returns
     -------
-    RawNpy
+    RawNPY
         The raw data.
     """
-    return RawNpy(fname, fs, transpose)
+    return RawNPY(fname, fs, transpose)
 
 
 def parse_npy(fname):

--- a/src/mnelab/io/npy.py
+++ b/src/mnelab/io/npy.py
@@ -1,0 +1,66 @@
+import mne
+import numpy as np
+from mne.io import BaseRaw
+
+
+class RawNpy(BaseRaw):
+    """Raw data from .npy file."""
+
+    def __init__(self, fname, fs, transpose=False, *args, **kwargs):
+        """Read raw data from .npy file.
+
+        Parameters
+        ----------
+        fname : str
+            File name to load.
+        fs : float
+            Sampling frequency (in Hz).
+        transpose : bool
+            Whether to transpose the data, the data should be of shape (channels, samples).
+        """
+        data = np.load(fname)
+        if transpose:
+            data = data.T
+        if data.ndim != 2:
+            raise ValueError(f"Array must have two dimensions (got {data.ndim}).")
+        info = mne.create_info(data.shape[0], fs)
+        super().__init__(preload=data, info=info, filenames=[fname])
+
+
+def read_raw_npy(fname, fs, transpose=False, *args, **kwargs):
+    """Read raw data from .npy file.
+
+    Parameters
+    ----------
+    fname : str
+        File name to load.
+    fs : float
+        Sampling frequency (in Hz).
+    transpose : bool
+        Whether to transpose the data, the data should be of shape (channels, samples).
+
+    Returns
+    -------
+    RawNpy
+        The raw data.
+    """
+    return RawNpy(fname, fs, transpose)
+
+
+def parse_npy(fname):
+    """Return shape of array contained in .npy file.
+
+    Parameters
+    ----------
+    fname : str
+        File name to load.
+
+    Returns
+    -------
+    shape : tuple[int, int]
+        The shape of the array.
+    """
+    with open(fname, "rb") as f:
+        np.lib.format.read_magic(f)
+        shape, _, _ = np.lib.format.read_array_header_1_0(f)
+    return shape

--- a/src/mnelab/io/readers.py
+++ b/src/mnelab/io/readers.py
@@ -6,9 +6,9 @@ from functools import partial
 from pathlib import Path
 
 import mne
-import numpy as np
 
 from mnelab.io.mat import read_raw_mat
+from mnelab.io.npy import read_raw_npy
 from mnelab.io.xdf import read_raw_xdf
 
 
@@ -19,56 +19,6 @@ def _read_unsupported(fname, **kwargs):
     if suggest is not None:
         msg += f" Try reading a {suggest} file instead."
     raise ValueError(msg)
-
-
-def read_numpy(fname, sfreq, transpose=False, *args, **kwargs):
-    """Load 2D array from .npy file.
-
-    Parameters
-    ----------
-    fname : str
-        File name to load.
-    sfreq : float
-        Sampling frequency.
-    transpose : bool
-        Whether to transpose the array.
-
-    Returns
-    -------
-    raw : mne.io.Raw
-        Raw object.
-    """
-    npy = np.load(fname)
-    if transpose:
-        npy = npy.T
-
-    if npy.ndim != 2:
-        raise ValueError(f"Array must have two dimensions (got {npy.ndim}).")
-
-    # create Raw structure
-    info = mne.create_info(npy.shape[0], sfreq)
-    raw = mne.io.RawArray(npy, info=info)
-    raw._filenames = [fname]
-    return raw
-
-
-def parse_npy(fname):
-    """Return shape of array contained in .npy file.
-
-    Parameters
-    ----------
-    fname : str
-        File name to load.
-
-    Returns
-    -------
-    shape : tuple[int, int]
-        The shape of the array.
-    """
-    with open(fname, "rb") as f:
-        np.lib.format.read_magic(f)
-        shape, _, _ = np.lib.format.read_array_header_1_0(f)
-    return shape
 
 
 # supported read file formats
@@ -89,7 +39,7 @@ supported = {
     ".xdfz": read_raw_xdf,
     ".xdf.gz": read_raw_xdf,
     ".mat": read_raw_mat,
-    ".npy": read_numpy,
+    ".npy": read_raw_npy,
 }
 
 # known but unsupported file formats

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -32,7 +32,7 @@ from pyxdf import resolve_streams
 from mnelab.dialogs import *  # noqa: F403
 from mnelab.io import writers
 from mnelab.io.mat import parse_mat
-from mnelab.io.readers import parse_npy
+from mnelab.io.npy import parse_npy
 from mnelab.io.xdf import get_xml, list_chunks
 from mnelab.model import InvalidAnnotationsError, LabelsNotFoundError, Model
 from mnelab.settings import SettingsDialog, read_settings, write_settings


### PR DESCRIPTION
This is the recommended and documented approach, which specifically means that we do not have to fiddle with the private `._filenames` attribute anymore.

- [x] `.mat`
- [x] `.npy`
- [x] `.xdf`/`.xdfz`

This is what you meant, right @larsoner?