### PR TITLE
Use uv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     name: Run tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-24.04
-    env:
-      DISPLAY: ':99.0'
     steps:
     - uses: actions/checkout@v4
     - name: Install uv
@@ -34,12 +32,10 @@ jobs:
     - name: Install Linux packages
       run: |
         sudo apt update
-        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1 libdbus-1-3
-        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
-    #     sudo apt install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
-    #                      libxkbcommon-x11-0 xvfb libxcb-randr0 \
-    #                      libxcb-render-util0 libxcb-xinerama0 libegl1 \
-    #                      libxcb-shape0 libxcb-cursor0
+        sudo apt install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+                         libxkbcommon-x11-0 xvfb libxcb-randr0 \
+                         libxcb-render-util0 libxcb-xinerama0 libegl1 \
+                         libxcb-shape0 libxcb-cursor0
     - name: Install the project
       run: uv sync --all-extras
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,10 @@ jobs:
       uses: astral-sh/setup-uv@v3
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}
-    # - name: Install Linux packages
-    #   run: |
-    #     sudo apt update
+    - name: Install Linux packages
+      run: |
+        sudo apt update
+        sudo apt install libegl-dev
     #     sudo apt install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
     #                      libxkbcommon-x11-0 xvfb libxcb-randr0 \
     #                      libxcb-render-util0 libxcb-xinerama0 libegl1 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
     - name: Install Linux packages
       run: |
         sudo apt update
@@ -35,13 +36,7 @@ jobs:
                          libxkbcommon-x11-0 xvfb libxcb-randr0 \
                          libxcb-render-util0 libxcb-xinerama0 libegl1 \
                          libxcb-shape0 libxcb-cursor0
-    - name: Build sdist and wheel
-      run: |
-        pip install build
-        python -m build
-    - name: Install wheel
-      run: |
-        pip install pytest-qt pytest-xvfb
-        pip install "$(pwd)/$(echo dist/mnelab*.whl)[dev]"
+    - name: Install the project
+      run: uv sync --all-extras
     - name: Run tests
-      run: pytest
+      run: uv run pytest tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,13 @@ jobs:
       uses: astral-sh/setup-uv@v3
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}
-    - name: Install Linux packages
-      run: |
-        sudo apt update
-        sudo apt install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
-                         libxkbcommon-x11-0 xvfb libxcb-randr0 \
-                         libxcb-render-util0 libxcb-xinerama0 libegl1 \
-                         libxcb-shape0 libxcb-cursor0
+    # - name: Install Linux packages
+    #   run: |
+    #     sudo apt update
+    #     sudo apt install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+    #                      libxkbcommon-x11-0 xvfb libxcb-randr0 \
+    #                      libxcb-render-util0 libxcb-xinerama0 libegl1 \
+    #                      libxcb-shape0 libxcb-cursor0
     - name: Install the project
       run: uv sync --all-extras
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     name: Run tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-24.04
+    env:
+      DISPLAY: ':99.0'
     steps:
     - uses: actions/checkout@v4
     - name: Install uv
@@ -32,7 +34,8 @@ jobs:
     - name: Install Linux packages
       run: |
         sudo apt update
-        sudo apt install libegl-dev
+        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
+        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
     #     sudo apt install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
     #                      libxkbcommon-x11-0 xvfb libxcb-randr0 \
     #                      libxcb-render-util0 libxcb-xinerama0 libegl1 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Linux packages
       run: |
         sudo apt update
-        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
+        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1 libdbus-1-3
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
     #     sudo apt install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
     #                      libxkbcommon-x11-0 xvfb libxcb-randr0 \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,13 @@ Open a terminal and change into the folder where you would like your MNELAB fork
 
 ### Installing required Python packages
 
-In a terminal, change to the `mnelab` folder containing your MNELAB fork. You can install the package and all dependencies with the following command:
+In a terminal, change to the `mnelab` folder containing your MNELAB fork. We recommend [`uv`](https://docs.astral.sh/uv/) as a package and project manager, but you can use any standard-compliant tool of your choice. With `uv`, you can install MNELAB and all development dependencies with the following command in the project root:
 
 ```
-pip install -e ".[dev]"
+uv sync --python=3.9 --all-extras
 ```
 
-You might want to [create a virtual environment](https://docs.python.org/3/library/venv.html#creating-virtual-environments) instead of installing everything into your global environment.
+You can then run MNELAB with `uv run mnelab`, or run the tests with `uv run pytest`. We recommend to use the minimum required Python version (currently 3.9) to ensure compatibility with this release.
 
 
 ### Creating a new branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ full = [
 dev = [
     "mnelab[full]",
     "pytest",
-    # "pytest-qt",
+    "pytest-qt",
     "ruff",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "mnelab[full]",
     "pytest",
     "pytest-qt",
+    "pytest-xvfb",
     "ruff",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
     "PySide6 >= 6.7.1",
     "edfio >= 0.4.2",
     "matplotlib >= 3.8.0",
-    "numpy >= 1.25.0",
+    "numpy >= 2.0.0",
     "scipy >= 1.10.0",
-    "pybv >= 0.7.4",  # brainvision
+    "pybv >= 0.7.4",
     "pyxdf >= 1.16.4",
     "pyobjc-framework-Cocoa >= 10.0; platform_system=='Darwin'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ full = [
 dev = [
     "mnelab[full]",
     "pytest",
-    "pytest-qt",
+    # "pytest-qt",
     "ruff",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ full = [
 ]
 dev = [
     "mnelab[full]",
-    "build",
     "pytest",
     "pytest-qt",
     "ruff",

--- a/src/mnelab/io/writers.py
+++ b/src/mnelab/io/writers.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import mne
 import numpy as np
-from numpy.core.records import fromarrays
+from numpy.rec import fromarrays
 from scipy.io import savemat
 
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -5,16 +5,15 @@
 from mnelab import MainWindow, Model
 
 
-def test_initial_actions(qtbot):
+def test_initial_actions():
     """Test if initial actions are correctly enabled/disabled."""
-    assert True
     model = Model()
     view = MainWindow(model)
     model.view = view
-    qtbot.addWidget(view)
+    # qtbot.addWidget(view)
 
-    for name, action in view.actions.items():
-        if name in view.always_enabled:
-            assert action.isEnabled()
-        else:
-            assert not action.isEnabled()
+    # for name, action in view.actions.items():
+    #     if name in view.always_enabled:
+    #         assert action.isEnabled()
+    #     else:
+    #         assert not action.isEnabled()

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -5,15 +5,15 @@
 from mnelab import MainWindow, Model
 
 
-def test_initial_actions():
+def test_initial_actions(qtbot):
     """Test if initial actions are correctly enabled/disabled."""
     model = Model()
     view = MainWindow(model)
     model.view = view
-    # qtbot.addWidget(view)
+    qtbot.addWidget(view)
 
-    # for name, action in view.actions.items():
-    #     if name in view.always_enabled:
-    #         assert action.isEnabled()
-    #     else:
-    #         assert not action.isEnabled()
+    for name, action in view.actions.items():
+        if name in view.always_enabled:
+            assert action.isEnabled()
+        else:
+            assert not action.isEnabled()


### PR DESCRIPTION
Use uv (also in test runners). In addition, I've bumped NumPy to >= 2.0, because of an API change (this will only cause problems if a dependency has a pin on NumPy < 2, which is currently not the case).