### PR TITLE
Filter Qt warnings

### DIFF
--- a/src/mnelab/__init__.py
+++ b/src/mnelab/__init__.py
@@ -3,6 +3,7 @@
 # License: BSD (3-clause)
 
 import multiprocessing as mp
+import os
 import sys
 from pathlib import Path
 
@@ -18,6 +19,7 @@ __version__ = "1.0.0.dev0"
 
 
 def main():
+    os.environ["QT_LOGGING_RULES"] = "*.debug=false;*.warning=false"
     mp.set_start_method("spawn", force=True)  # required for Linux
     app_name = "MNELAB"
     if sys.platform.startswith("darwin"):

--- a/src/mnelab/__init__.py
+++ b/src/mnelab/__init__.py
@@ -3,12 +3,11 @@
 # License: BSD (3-clause)
 
 import multiprocessing as mp
-import os
 import sys
 from pathlib import Path
 
 import matplotlib
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QLoggingCategory, Qt
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication
 
@@ -19,7 +18,7 @@ __version__ = "1.0.0.dev0"
 
 
 def main():
-    os.environ["QT_LOGGING_RULES"] = "*.debug=false;*.warning=false"
+    QLoggingCategory.setFilterRules("*.debug=false\n*.warning=false")
     mp.set_start_method("spawn", force=True)  # required for Linux
     app_name = "MNELAB"
     if sys.platform.startswith("darwin"):


### PR DESCRIPTION
To avoid cluttering the stdout with Qt warning and debug messages, this PR disables them. Of course, this assumes that they are actually not important, but we can always enable them again if we ever encounter a Qt-related bug.