### PR TITLE
Bump picard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 keywords = ["EEG", "MEG", "MNE", "GUI", "electrophysiology"]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 full = [
     "mne-qt-browser >= 0.6.2",  # alternative browser backend
-    "python-picard >= 0.7.0",  # picard
+    "python-picard >= 0.8.0",  # picard
     "scikit-learn >= 1.3.0",  # fastica
 ]
 dev = [


### PR DESCRIPTION
Since picard does not depend on numexpr anymore, we can finally officially support Python 3.13.