### PR TITLE
Correctly load marker streams from .xdf files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Remove Python 3.9 support ([#457](https://github.com/cbrnr/mnelab/pull/457) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
+- Fix an issue where some .xdf files were not loaded correctly (wrong dtype or multi-channel marker) ([#464](https://github.com/cbrnr/mnelab/pull/464) by [Benedikt Klöckl](https://github.com/bkloeckl))
 - Fix a bug where appending data would not be correctly displayed in the history ([#446](https://github.com/cbrnr/mnelab/pull/446) by [Benedikt Klöckl](https://github.com/bkloeckl))
 - Fix resetting the settings to default values ([#456](https://github.com/cbrnr/mnelab/pull/456) by [Clemens Brunner](https://github.com/cbrnr))
 

--- a/src/mnelab/dialogs/xdf_streams.py
+++ b/src/mnelab/dialogs/xdf_streams.py
@@ -153,7 +153,6 @@ class XDFStreamsDialog(QDialog):
             fs = self.view.item(row.row(), 5).value()
             if not _is_marker(type_) and fs != 0:
                 streams.append(self.view.item(row.row(), 0).value())
-        print("return streams: ", streams)
         return streams
 
     @property
@@ -164,7 +163,6 @@ class XDFStreamsDialog(QDialog):
             # fs = self.view.item(row.row(), 5).value()
             if _is_marker(type_):
                 markers.append(self.view.item(row.row(), 0).value())
-        print("return markers: ", markers)
         return markers
 
 

--- a/src/mnelab/dialogs/xdf_streams.py
+++ b/src/mnelab/dialogs/xdf_streams.py
@@ -160,7 +160,6 @@ class XDFStreamsDialog(QDialog):
         markers = []
         for row in self.view.selectionModel().selectedRows():
             type_ = self.view.item(row.row(), 2).text()
-            # fs = self.view.item(row.row(), 5).value()
             if _is_marker(type_):
                 markers.append(self.view.item(row.row(), 0).value())
         return markers

--- a/src/mnelab/dialogs/xdf_streams.py
+++ b/src/mnelab/dialogs/xdf_streams.py
@@ -151,8 +151,9 @@ class XDFStreamsDialog(QDialog):
         for row in self.view.selectionModel().selectedRows():
             type_ = self.view.item(row.row(), 2).text()
             fs = self.view.item(row.row(), 5).value()
-            if type_ != "Markers" and fs != 0:
+            if not _is_marker(type_) and fs != 0:
                 streams.append(self.view.item(row.row(), 0).value())
+        print("return streams: ", streams)
         return streams
 
     @property
@@ -160,7 +161,13 @@ class XDFStreamsDialog(QDialog):
         markers = []
         for row in self.view.selectionModel().selectedRows():
             type_ = self.view.item(row.row(), 2).text()
-            fs = self.view.item(row.row(), 5).value()
-            if type_ == "Markers" and fs == 0:
+            # fs = self.view.item(row.row(), 5).value()
+            if _is_marker(type_):
                 markers.append(self.view.item(row.row(), 0).value())
+        print("return markers: ", markers)
         return markers
+
+
+def _is_marker(type):
+    marker_types = ["Markers", "Marker", "StringMarker"]
+    return type in marker_types


### PR DESCRIPTION
Fixes [#451](https://github.com/cbrnr/mnelab/issues/451) in order to load XDF containing multi-channel marker stream. Also addresses some minor issues to recognize different names of marker types and auto-convert stream dtype to supported types if possible.