### PR TITLE
Exclude PySide 6.8.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["EEG", "MEG", "MNE", "GUI", "electrophysiology"]
 dependencies = [
     "mne >= 1.7.0",
-    "PySide6 >= 6.7.1; != 6.8.1.1",
+    "PySide6 >= 6.7.1, != 6.8.1.1",
     "edfio >= 0.4.2",
     "matplotlib >= 3.8.0",
     "numpy >= 2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["EEG", "MEG", "MNE", "GUI", "electrophysiology"]
 dependencies = [
     "mne >= 1.7.0",
-    "PySide6 >= 6.7.1",
+    "PySide6 >= 6.7.1; != 6.8.1.1",
     "edfio >= 0.4.2",
     "matplotlib >= 3.8.0",
     "numpy >= 2.0.0",


### PR DESCRIPTION
This should fix CI errors with PySide 6.8.1.1 not being installable on non-macOS platforms.