### PR TITLE
Use standard Close button

### DIFF
--- a/src/mnelab/dialogs/channel_stats.py
+++ b/src/mnelab/dialogs/channel_stats.py
@@ -6,7 +6,6 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
-    QPushButton,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,

--- a/src/mnelab/dialogs/channel_stats.py
+++ b/src/mnelab/dialogs/channel_stats.py
@@ -5,6 +5,7 @@
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QDialog,
+    QDialogButtonBox,
     QPushButton,
     QTableWidget,
     QTableWidgetItem,
@@ -45,9 +46,9 @@ class ChannelStats(QDialog):
         self.table.resizeColumnsToContents()
 
         # add close button
-        close_button = QPushButton("Close")
-        close_button.clicked.connect(self.close)
-        layout.addWidget(close_button)
+        buttonbox = QDialogButtonBox(QDialogButtonBox.Close)
+        layout.addWidget(buttonbox)
+        buttonbox.rejected.connect(self.reject)
 
         # calculate table width
         table_width = self.table.verticalHeader().width()


### PR DESCRIPTION
The Channel Stats dialog used a Close button that extended over the entire dialog width. Using a `QDialogButtonBox` ensures that the platform default layout is used.