### PR TITLE
Add dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,9 @@ full = [
     "python-picard >= 0.8.0",  # picard
     "scikit-learn >= 1.3.0",  # fastica
 ]
+
+[dependency-groups]
 dev = [
-    "mnelab[full]",
     "pytest",
     "pytest-qt",
     "pytest-xvfb",


### PR DESCRIPTION
This is the recommended way to add dev dependencies now (which replaces optional dependencies). Note that `uv sync` and `uv run` automatically install the dev dependency group.