### PR TITLE
Run pytest with warnings as errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Install the project
       run: uv sync --all-extras
     - name: Run tests
-      run: uv run pytest tests
+      run: uv run pytest -W error tests


### PR DESCRIPTION
This helps catch more potential errors, as all tests should pass without warnings and errors.