### PR TITLE
Update mainwindow.py

### DIFF
--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -74,7 +74,8 @@ class MainWindow(QMainWindow):
         self.installEventFilter(self)
 
         # remove None entries from self.recent
-        self.recent = [recent for recent in self.recent if recent is not None]
+        if self.recent != None:
+            self.recent = [recent for recent in self.recent if recent is not None]
 
         # plot backend
         self.plot_backends = ["Matplotlib"]


### PR DESCRIPTION
if self.recent is None (at the first start), MNELAB otherwise crashes with this error message:

Traceback (most recent call last):
[...]
  File "/opt/Software4EEG/MNE/lib/python3.12/site-packages/mnelab/mainwindow.py", line 78, in __init__
    self.recent = [recent for recent in self.recent if recent is not None]
[...]
TypeError: 'NoneType' object is not iterable