### PR TITLE
Increase width of Events and Annotations dialogs

### DIFF
--- a/src/mnelab/dialogs/annotations.py
+++ b/src/mnelab/dialogs/annotations.py
@@ -61,8 +61,7 @@ class AnnotationsDialog(QDialog):
         self.add_button.clicked.connect(self.toggle_buttons)
         self.counts_button.clicked.connect(self.open_counts_dialog)
         self.toggle_buttons()
-        self.setMinimumSize(500, 500)
-        self.resize(500, 500)
+        self.setMinimumSize(600, 500)
 
     @property
     def unique_annotations(self):

--- a/src/mnelab/dialogs/events.py
+++ b/src/mnelab/dialogs/events.py
@@ -65,8 +65,7 @@ class EventsDialog(QDialog):
         self.counts_button.clicked.connect(self.open_counts_dialog)
         self.mapping_button.clicked.connect(self.open_mapping_dialog)
         self.toggle_buttons()
-        self.setMinimumSize(500, 500)
-        self.resize(500, 500)
+        self.setMinimumSize(600, 500)
 
     @property
     def unique_events(self):


### PR DESCRIPTION
The previous width was to narrow to fit all buttons on some platforms/settings.