### PR TITLE
Change method of obtaining package versions

### DIFF
--- a/src/mnelab/utils/dependencies.py
+++ b/src/mnelab/utils/dependencies.py
@@ -6,7 +6,7 @@ from importlib.metadata import version, PackageNotFoundError
 from itertools import chain
 
 required = ("mne", "PySide6", "edfio", "matplotlib", "numpy", "pyxdf", "scipy", "pybv")
-optional = ("mne-qt-browser", "picard", "scikit-learn")
+optional = ("mne-qt-browser", "python-picard", "scikit-learn")
 
 have = {}
 for package in chain(required, optional):

--- a/src/mnelab/utils/dependencies.py
+++ b/src/mnelab/utils/dependencies.py
@@ -2,20 +2,15 @@
 #
 # License: BSD (3-clause)
 
-from importlib import import_module
+from importlib.metadata import version, PackageNotFoundError
+from itertools import chain
 
-required = ["mne", "PySide6", "edfio", "matplotlib", "numpy", "pyxdf", "scipy", "pybv"]
-optional = ["mne-qt-browser", "picard", "sklearn"]
+required = ("mne", "PySide6", "edfio", "matplotlib", "numpy", "pyxdf", "scipy", "pybv")
+optional = ("mne-qt-browser", "picard", "scikit-learn")
 
 have = {}
-for package in required + optional:
+for package in chain(required, optional):
     try:
-        mod = import_module(package.replace("-", "_"))
-    except ModuleNotFoundError:
+        have[package] = version(package)
+    except PackageNotFoundError:
         have[package] = False
-    else:  # module successfully imported
-        try:
-            version = mod.__version__
-        except AttributeError:
-            version = "unknown"
-        have[package] = version


### PR DESCRIPTION
Hello!

While testing the ICA feature, I noticed that the About window indicated that `sklearn` was not installed. However, when I tried to install `sklearn` with:

```
uv add sklearn
```

uv displayed the following error message:.

```
      [stderr]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
```

This motivated this PR: `sklearn` is a deprecated package name and should not be used.

This PR uses `importlib.metadata.version`, introduced in Python 3.8, to obtain package versions instead of relying on `__version__`.  `version('scikit-learn')` also works well.  

The only "drawback" of this approach is that it depends on the information provided in the `.dist-info` directory, so these details need to be included when packaging with PyInstaller.

References:

- [How do I check the versions of Python modules?](https://stackoverflow.com/questions/20180543/how-do-i-check-the-versions-of-python-modules)
- https://docs.python.org/3/library/importlib.metadata.html#distribution-versions
- https://packaging.python.org/en/latest/specifications/recording-installed-packages/