### PR TITLE
Switch to uv-build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.7.19,<0.8.0"]
+build-backend = "uv_build"
 
 [project]
 name = "mnelab"


### PR DESCRIPTION
Since uv-build is now stable, and MNELAB is pure Python only, it makes sense to switch the build backend also because I'm already using uv all over the place 😍.