### PR TITLE
Install pytest-xvfb only on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ full = [
 dev = [
     "pytest",
     "pytest-qt",
-    "pytest-xvfb",
+    "pytest-xvfb; platform_system=='Linux'",
     "ruff",
 ]
 


### PR DESCRIPTION
Simply because it won't work on other platforms anyway.