### PR TITLE
Explicitly use latest Ruff version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
-        with:
-          version: "latest"
       - uses: astral-sh/ruff-action@v3
         with:
-          version: "latest"
           args: "format --diff"
 
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "pytest",
     "pytest-qt",
     "pytest-xvfb; platform_system=='Linux'",
-    "ruff",
+    "ruff >= 0.12.3",
 ]
 
 [project.gui-scripts]


### PR DESCRIPTION
Hopefully this avoids the warnings in the action.