### PR TITLE
Add `license-files` entry to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "mnelab"
 version = "1.0.3"
 description = "A graphical user interface for MNE"
 license = {text = "BSD 3-Clause"}
+license-files = ["LICENSE"]
 authors = [
     {name = "Clemens Brunner", email = "clemens.brunner@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "mnelab"
 version = "1.0.3"
 description = "A graphical user interface for MNE"
-license = "BSD 3-Clause"
+license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 authors = [
     {name = "Clemens Brunner", email = "clemens.brunner@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "mnelab"
 version = "1.0.3"
 description = "A graphical user interface for MNE"
-license = {text = "BSD 3-Clause"}
+license = "BSD 3-Clause"
 license-files = ["LICENSE"]
 authors = [
     {name = "Clemens Brunner", email = "clemens.brunner@gmail.com"},


### PR DESCRIPTION
This should ensure `LICENSE` is included in the sdist built by `uv-build`.

Note that I have not tested this ;) 

Please see:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files