### PR TITLE
Redirect stdout/stderr for frozen Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
 ### 🔧 Fixed
-- Fix a bug with the Windows standalone version where filtering would not work ([#503](https://github.com/cbrnr/mnelab/pull/503) by [Clemens Brunner](https://github.com/cbrnr))
+- Fix issues with the standalone versions ([#503](https://github.com/cbrnr/mnelab/pull/503) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.0.3] - 2025-07-15
 ### ✨ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### 🔧 Fixed
+- Fix a bug with the Windows standalone version where filtering would not work ([#503](https://github.com/cbrnr/mnelab/pull/503) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.0.3] - 2025-07-15
 ### ✨ Added

--- a/src/mnelab/__init__.py
+++ b/src/mnelab/__init__.py
@@ -2,8 +2,16 @@
 #
 # License: BSD (3-clause)
 
-import multiprocessing as mp
+import io
 import sys
+
+if getattr(sys, "frozen", False):
+    if sys.stdout is None:
+        sys.stdout = io.StringIO()
+    if sys.stderr is None:
+        sys.stderr = io.StringIO()
+
+import multiprocessing as mp
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 

--- a/standalone/create-standalone-linux.sh
+++ b/standalone/create-standalone-linux.sh
@@ -1,6 +1,7 @@
 pyinstaller \
     --collect-all mne \
     --collect-all mnelab \
+    --collect-all sklearn \
     --name MNELAB \
     --windowed \
     --noupx \

--- a/standalone/create-standalone-windows.ps1
+++ b/standalone/create-standalone-windows.ps1
@@ -1,6 +1,7 @@
 pyinstaller `
     --collect-all mne `
     --collect-all mnelab `
+    --collect-all sklearn `
     --name MNELAB `
     --windowed `
     --noupx `

--- a/standalone/mnelab-macos.spec
+++ b/standalone/mnelab-macos.spec
@@ -8,6 +8,8 @@ tmp_ret = collect_all('mne')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 tmp_ret = collect_all('mnelab')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+tmp_ret = collect_all('sklearn')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 
 
 a = Analysis(


### PR DESCRIPTION
I think this is the required fix for the error that the Windows standalone version currently throws when trying to filter data:

```
Traceback (most recent call last):
File "joblib\parallel.py", line 1916, in _get_sequential_output
File "joblib\parallel.py", line 1608, in print_progress
File "joblib\parallel.py", line 1558, in _print
AttributeError: 'NoneType' object has no attribute 'write'
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
File "mnelab\mainwindow.py", line 1135, in filter_data
self.model.filter(dialog.lower, dialog.upper, dialog.notch)
~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "mnelab\model.py", line 38, in wrapper
result = f(self, *args, **kwargs)
File "mnelab\model.py", line 516, in filter
self.current["data"].filter(None, upper)
~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
File "mne\io\base.py", line 1174, in filter
return super().filter(
~~~~~~~~~~~~~~^
l_freq,
^^^^^^^
...<13 lines>...
verbose=verbose,
^^^^^^^^^^^^^^^^
)
^
File "<decorator-gen-78>", line 12, in filter
File "mne\filter.py", line 2562, in filter
filter_data(
~~~~~~~~~~~^
self._data[:, start:stop],
^^^^^^^^^^^^^^^^^^^^^^^^^^
...<15 lines>...
verbose=use_verbose,
^^^^^^^^^^^^^^^^^^^^
)
^
File "<decorator-gen-73>", line 12, in filter_data
File "mne\filter.py", line 1027, in filter_data
data = _overlap_add_filter(data, filt, None, phase, picks, n_jobs, copy, pad)
File "mne\filter.py", line 346, in _overlap_add_filter
data_new = parallel(
p_fun(x[p], len(h), n_edge, phase, cuda_dict, pad, n_fft) for p in picks
)
File "joblib\parallel.py", line 1986, in __call__
File "joblib\parallel.py", line 1928, in _get_sequential_output
File "joblib\parallel.py", line 1617, in print_progress
AttributeError: 'Parallel' object has no attribute '_pre_dispatch_amount'
```

Also, due to a recent change in `sklearn`, we now need to include `--collect-all sklearn`, as PyInstaller no longer detects all related submodules automatically.