### PR TITLE
Use consistent settings path and INI format

### DIFF
--- a/src/mnelab/__init__.py
+++ b/src/mnelab/__init__.py
@@ -52,7 +52,7 @@ def main():
     app.setApplicationName("mnelab")
     app.setApplicationDisplayName("MNELAB")
     app.setDesktopFileName("mnelab")
-    app.setOrganizationName("cbrnr")
+    app.setOrganizationName("mnelab")
     if sys.platform.startswith("darwin"):
         app.setAttribute(Qt.ApplicationAttribute.AA_DontShowIconsInMenus, True)
         app.setWindowIcon(QIcon(f"{Path(__file__).parent}/icons/mnelab-logo-macos.svg"))
@@ -60,7 +60,6 @@ def main():
         app.setWindowIcon(QIcon(f"{Path(__file__).parent}/icons/mnelab-logo.svg"))
     if sys.platform.startswith("win"):
         app.setStyle("fusion")
-    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
     model = Model()
     model.view = MainWindow(model)
     app.mainwindow = model.view

--- a/src/mnelab/settings.py
+++ b/src/mnelab/settings.py
@@ -1,9 +1,10 @@
 # © MNELAB developers
 #
 # License: BSD (3-clause)
+from pathlib import Path
 
 from mne import get_config_path
-from PySide6.QtCore import QPoint, QSettings, QSize, QUrl, Slot
+from PySide6.QtCore import QPoint, QSettings, QSize, QStandardPaths, QUrl, Slot
 from PySide6.QtGui import QDesktopServices, Qt
 from PySide6.QtWidgets import (
     QComboBox,
@@ -14,6 +15,16 @@ from PySide6.QtWidgets import (
     QLabel,
     QSpinBox,
 )
+
+SETTINGS_PATH = str(
+    Path(
+        QStandardPaths.writableLocation(
+            QStandardPaths.StandardLocation.AppConfigLocation
+        )
+    )
+    / "mnelab.ini"
+)
+
 
 _DEFAULTS = {
     "max_recent": 6,
@@ -28,7 +39,7 @@ _DEFAULTS = {
 
 
 def _get_value(key):
-    return QSettings().value(
+    return QSettings(SETTINGS_PATH, QSettings.Format.IniFormat).value(
         key, defaultValue=_DEFAULTS[key], type=type(_DEFAULTS[key])
     )
 
@@ -57,15 +68,16 @@ def read_settings(key=None):
 
 def write_settings(**kwargs):
     """Write application settings."""
+    settings = QSettings(SETTINGS_PATH, QSettings.Format.IniFormat)
     for key, value in kwargs.items():
         if key not in _DEFAULTS:
             raise KeyError(f"Invalid setting key: {key}")
-        QSettings().setValue(key, value)
+        settings.setValue(key, value)
 
 
 def clear_settings():
     """Clear all settings."""
-    QSettings().clear()
+    QSettings(SETTINGS_PATH, QSettings.Format.IniFormat).clear()
 
 
 class SettingsDialog(QDialog):
@@ -98,10 +110,9 @@ class SettingsDialog(QDialog):
         self.max_channels.setAlignment(Qt.AlignRight)
         grid.addWidget(self.max_channels, 2, 1)
 
-        mnelab_config_path = QSettings().fileName()
         mnelab_label = QLabel(
-            f'<i>Settings are stored in <a href="{mnelab_config_path}">'
-            f"{mnelab_config_path}</a>.</i>"
+            f'<i>Settings are stored in <a href="{SETTINGS_PATH}">'
+            f"{SETTINGS_PATH}</a>.</i>"
         )
         mnelab_label.linkActivated.connect(self.open_path)
         grid.addWidget(mnelab_label, 3, 0, 1, 2)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,17 +1,14 @@
 import pytest
-from PySide6.QtCore import QSettings
 
+from mnelab import settings
 from mnelab.settings import _DEFAULTS, clear_settings, read_settings, write_settings
 
 
 @pytest.fixture(autouse=True)
-def temp_settings(tmp_path):
-    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
-    QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, str(tmp_path))
-    settings = QSettings()
-    settings.clear()
-    yield
-    settings.clear()
+def temp_settings(tmp_path, monkeypatch):
+    """Redirect settings to a temporary folder for tests."""
+    temp_file = str(tmp_path / "mnelab.ini")
+    monkeypatch.setattr(settings, "SETTINGS_PATH", temp_file)
 
 
 def test_read_default_settings():


### PR DESCRIPTION
Previously, existing config files (in different formats, such as `.plist` on macOS) could influence the behavior. This PR makes sure that INI files are always used on all platforms.

The settings locations should be:

- macOS: `~/Library/Preferences/mnelab.ini`
- Linux: `~/.config/mnelab.ini`
- Windows: `C:\Users\<YourUsername>\AppData\Roaming\mnelab.ini`

The path is also shown in the Settings dialog.