### PR TITLE
Remove PySide < 6.10.0 pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### 🌀 Changed
+- PySide6 >= 6.10.0 can now also be used on macOS since the performance regression has been fixed with a new PyQtGraph 0.14.0 release ([#533](https://github.com/cbrnr/mnelab/pull/533) by [Clemens Brunner](https://github.com/cbrnr))
+
 ### 🔧 Fixed
 - Fix ERDS maps and evoked topomaps plotting ([#530](https://github.com/cbrnr/mnelab/pull/530) by [Fabian Schellander](https://github.com/SchellanderF))
 - Disable "Counts" button in Events dialog when no events are present ([#529](https://github.com/cbrnr/mnelab/pull/529) by [Fabian Schellander](https://github.com/SchellanderF))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "numpy >= 2.0.0",
     "pybv >= 0.7.4",
     "pyxdf >= 1.16.4",
-    "pyside6 >= 6.9.3, < 6.10.0",  # >= 6.10.0 causes performance issues with pyqtgraph <= 0.13.7 on macOS (can be removed with a new pyqtgraph release)
+    "pyside6 >= 6.9.3",
     "scipy >= 1.14.1",
 ]
 


### PR DESCRIPTION
This is not required anymore because the new PyQtGraph 0.14.0 release fixed the issue.