### PR TITLE
Apply icon hover stylesheet only on macOS

### DIFF
--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -403,16 +403,17 @@ class MainWindow(QMainWindow):
         self.toolbar.addAction(self.actions["settings"])
         self.toolbar.setMovable(False)
         self.setUnifiedTitleAndToolBarOnMac(True)
-        self.toolbar.setStyleSheet("""
-            QToolButton:hover {
-                background: rgba(128, 128, 128, 0.2);
-                border-radius: 4px;
-            }
-            QToolButton:pressed {
-                background: rgba(128, 128, 128, 0.35);
-                border-radius: 4px;
-            }
-        """)
+        if sys.platform == "darwin":
+            self.toolbar.setStyleSheet("""
+                QToolButton:hover {
+                    background: rgba(128, 128, 128, 0.2);
+                    border-radius: 4px;
+                }
+                QToolButton:pressed {
+                    background: rgba(128, 128, 128, 0.35);
+                    border-radius: 4px;
+                }
+            """)
         if settings["toolbar"]:
             self.toolbar.show()
             self.actions["toolbar"].setChecked(True)


### PR DESCRIPTION
Both Linux and Windows already show hover effects by default.