### PR TITLE
Enhance annotation import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] · YYYY-MM-DD
+### ✨ Added
+- Add support for importing annotations from CSV files without a "type" column (assuming a single type) and for files where onset and duration are specified in samples ([#613](https://github.com/cbrnr/mnelab/pull/613) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.4.2] · 2026-03-24
 ### ✨ Added

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -31,6 +31,7 @@ from PySide6.QtGui import QAction, QDesktopServices, QIcon, QKeySequence
 from PySide6.QtWidgets import (
     QApplication,
     QFileDialog,
+    QInputDialog,
     QLabel,
     QMainWindow,
     QMenu,
@@ -925,24 +926,59 @@ class MainWindow(QMainWindow):
             return
         self._set_last_dir(fname)
         try:
-            all_types = get_annotation_types_from_file(fname)
+            all_types, integer = get_annotation_types_from_file(fname)
         except Exception as e:
             QMessageBox.critical(self, "Invalid annotations file", str(e))
             return
-        if len(all_types) > 1:
-            dialog = AnnotationTypesDialog(
+        # handle missing type column (ask the user for a description)
+        if all_types is None:
+            desc, ok = QInputDialog.getText(
                 self,
-                all_types,
-                title="Import annotations",
-                label="Select annotation types to import:",
+                "Import annotations",
+                "The file has no type column. Enter a description for all annotations:",
+                text="annotation",
             )
-            if not dialog.exec():
+            if not ok:
                 return
-            types = dialog.selected_types
+            description = desc.strip() or "annotation"
+            types = None
         else:
-            types = all_types
+            description = None
+            if len(all_types) > 1:
+                dialog = AnnotationTypesDialog(
+                    self,
+                    all_types,
+                    title="Import annotations",
+                    label="Select annotation types to import:",
+                )
+                if not dialog.exec():
+                    return
+                types = dialog.selected_types
+            else:
+                types = all_types
+        # check if all values look like integers (may be in samples)
+        unit = "seconds"
         try:
-            self.model.import_annotations(fname, types=types if types else None)
+            if integer:
+                sfreq = self.model.current["data"].info["sfreq"]
+                reply = QMessageBox.question(
+                    self,
+                    "Import annotations",
+                    f"All onset and duration values are integers. They may be in "
+                    f"samples (fs = {sfreq:.1f}\u202fHz) rather than "
+                    f"seconds.\n\nImport as samples?",
+                )
+                if reply == QMessageBox.StandardButton.Yes:
+                    unit = "samples"
+        except Exception:
+            pass
+        try:
+            self.model.import_annotations(
+                fname,
+                types=types if description is None else None,
+                description=description,
+                unit=unit,
+            )
         except InvalidAnnotationsError as e:
             QMessageBox.critical(self, "Invalid annotations", str(e))
 

--- a/src/mnelab/model.py
+++ b/src/mnelab/model.py
@@ -355,7 +355,7 @@ class Model:
             raise ValueError(f"Unsupported event file: {fname}")
 
     @data_changed
-    def import_annotations(self, fname, types=None):
+    def import_annotations(self, fname, types=None, description=None, unit="seconds"):
         """Import annotations from a CSV file.
 
         Parameters
@@ -363,40 +363,60 @@ class Model:
         fname : str
             Source file path.
         types : list of str or None
-            Annotation types (descriptions) to import.  If `None`, all types are
-            imported.
+            Annotation types to import. `None` imports all types.
+        description : str or None
+            Label assigned to every annotation when the file has no type column. Ignored
+            when the type column is present.
+        unit : str
+            `"seconds"` (default) or `"samples"`. When `"samples"`, onset and duration
+            values are divided by `sfreq` to convert them to seconds.
         """
         descs, onsets, durations = [], [], []
         fs = self.current["data"].info["sfreq"]
         try:
             with open(fname) as f:
                 header = f.readline().strip()
-                if header != "type,onset,duration":
+                has_type_col = header == "type,onset,duration"
+                no_type_col = header == "onset,duration"
+                if not has_type_col and not no_type_col:
                     raise InvalidAnnotationsError(
                         "Invalid annotations file (expected header: "
-                        "'type,onset,duration')."
+                        "'type,onset,duration' or 'onset,duration')."
                     )
                 for line in f:
                     annot = line.split(",")
-                    if len(annot) == 3:  # type, onset, duration
-                        desc = annot[0].strip()
-                        if types is not None and desc not in types:
+                    if has_type_col:
+                        if len(annot) < 3:
                             continue
-                        try:
-                            onset = float(annot[1].strip())
-                            duration = float(annot[2].strip())
-                        except ValueError:
-                            raise InvalidAnnotationsError(
-                                "One or more annotations have invalid onset or duration"
-                                " values."
-                            )
-                        if onset > self.current["data"].n_times / fs:
-                            raise InvalidAnnotationsError(
-                                "One or more annotations are outside the data range."
-                            )
-                        descs.append(desc)
-                        onsets.append(onset)
-                        durations.append(duration)
+                        desc = annot[0].strip()
+                        onset_str = annot[1].strip()
+                        duration_str = annot[2].strip()
+                    else:  # no type column
+                        if len(annot) < 2:
+                            continue
+                        desc = description if description is not None else "annotation"
+                        onset_str = annot[0].strip()
+                        duration_str = annot[1].strip()
+                    if types is not None and desc not in types:
+                        continue
+                    try:
+                        onset = float(onset_str)
+                        duration = float(duration_str)
+                    except ValueError:
+                        raise InvalidAnnotationsError(
+                            "One or more annotations have invalid onset or duration"
+                            " values."
+                        )
+                    if unit == "samples":
+                        onset /= fs
+                        duration /= fs
+                    if onset > self.current["data"].n_times / fs:
+                        raise InvalidAnnotationsError(
+                            "One or more annotations are outside the data range."
+                        )
+                    descs.append(desc)
+                    onsets.append(onset)
+                    durations.append(duration)
         except InvalidAnnotationsError:
             raise
         except UnicodeDecodeError:

--- a/src/mnelab/utils/utils.py
+++ b/src/mnelab/utils/utils.py
@@ -263,25 +263,48 @@ def merge_annotations(onsets, durations, descriptions):
 
 
 def get_annotation_types_from_file(fname):
-    """Return the sorted unique annotation types present in a CSV annotation file.
+    """Return annotation types and whether all numeric values are integers.
 
     Parameters
     ----------
     fname : str
-        Path to a CSV annotation file (type, onset, duration).
+        Path to a CSV annotation file with header `type,onset,duration` or
+        `onset,duration`.
 
     Returns
     -------
-    list of str
+    types : list of str or None
+        Sorted unique annotation types, or `None` if the file has no type column (header
+        is `onset,duration`).
+    integer : bool
+        `True` when the file has at least one data row and all onset and duration values
+        are whole numbers (useful for detecting if values are in samples or in seconds);
+        `False` otherwise.
     """
-    types = set()
     with open(fname) as f:
-        f.readline()  # skip header
+        header = f.readline().strip()
+        no_type = header == "onset,duration"
+        types = None if no_type else set()
+        found_any = False
+        all_integers = True
         for line in f:
-            parts = line.split(",")
-            if len(parts) == 3:
-                types.add(parts[0].strip())
-    return sorted(types)
+            parts = line.strip().split(",")
+            try:
+                if no_type:
+                    onset, dur = float(parts[0]), float(parts[1])
+                else:
+                    type_, onset, dur = (
+                        parts[0].strip(),
+                        float(parts[1]),
+                        float(parts[2]),
+                    )
+                    types.add(type_)
+            except (ValueError, IndexError):
+                continue
+            found_any = True
+            if onset != int(onset) or dur != int(dur):
+                all_integers = False
+    return (sorted(types) if types is not None else None), (found_any and all_integers)
 
 
 @dataclass

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -194,3 +194,58 @@ def test_import_annotations_outside_range_does_not_change_existing(
     annots = model_with_data.current["data"].annotations
     assert len(annots) == 1
     assert annots.description[0] == "EXISTING"
+
+
+def test_import_annotations_no_type_column(model_with_data, tmp_path):
+    """A two-column file (onset,duration) uses the supplied description."""
+    csv = tmp_path / "no_type.csv"
+    with open(csv, "w") as f:
+        f.write("onset,duration\n")
+        f.write("1.0,0.5\n")
+        f.write("5.0,1.0\n")
+    model_with_data.import_annotations(csv, description="BAD")
+    annots = model_with_data.current["data"].annotations
+    assert len(annots) == 2
+    assert list(annots.description) == ["BAD", "BAD"]
+    np.testing.assert_allclose(annots.onset, [1.0, 5.0])
+    np.testing.assert_allclose(annots.duration, [0.5, 1.0])
+
+
+def test_import_annotations_no_type_column_default_description(
+    model_with_data, tmp_path
+):
+    """A two-column file without a supplied description defaults to 'annotation'."""
+    csv = tmp_path / "no_type.csv"
+    with open(csv, "w") as f:
+        f.write("onset,duration\n")
+        f.write("1.0,0.5\n")
+    model_with_data.import_annotations(csv, description=None)
+    annots = model_with_data.current["data"].annotations
+    assert annots.description[0] == "annotation"
+
+
+def test_import_annotations_in_samples(model_with_data, tmp_path):
+    """When unit='samples', onset and duration are divided by sfreq."""
+    fs = model_with_data.current["data"].info["sfreq"]  # 256 Hz
+    csv = tmp_path / "samples.csv"
+    _write_annotations_csv(csv, [("BAD", int(1.0 * fs), int(0.5 * fs))])
+    model_with_data.import_annotations(csv, unit="samples")
+    annots = model_with_data.current["data"].annotations
+    assert len(annots) == 1
+    np.testing.assert_allclose(annots.onset, [1.0], rtol=1e-6)
+    np.testing.assert_allclose(annots.duration, [0.5], rtol=1e-6)
+
+
+def test_import_annotations_in_samples_no_type_column(model_with_data, tmp_path):
+    """unit='samples' works with two-column files as well."""
+    fs = model_with_data.current["data"].info["sfreq"]
+    csv = tmp_path / "samples_no_type.csv"
+    with open(csv, "w") as f:
+        f.write("onset,duration\n")
+        f.write(f"{int(2.0 * fs)},{int(1.0 * fs)}\n")
+    model_with_data.import_annotations(csv, description="STIM", unit="samples")
+    annots = model_with_data.current["data"].annotations
+    assert len(annots) == 1
+    assert annots.description[0] == "STIM"
+    np.testing.assert_allclose(annots.onset, [2.0], rtol=1e-6)
+    np.testing.assert_allclose(annots.duration, [1.0], rtol=1e-6)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,11 @@
 import numpy as np
 import pytest
 
-from mnelab.utils import annotations_between_events, merge_annotations
+from mnelab.utils import (
+    annotations_between_events,
+    get_annotation_types_from_file,
+    merge_annotations,
+)
 
 SFREQ = 100.0
 
@@ -355,3 +359,65 @@ def test_merge_annotations_contained_interval():
     np.testing.assert_allclose(m_onsets, [1.0])
     np.testing.assert_allclose(m_durations, [3.0])
     assert m_descriptions == ["A"]
+
+
+# --- get_annotation_types_from_file ---
+
+
+def test_get_annotation_types_from_file_three_column(tmp_path):
+    """Returns sorted unique types from a type,onset,duration file."""
+    csv = tmp_path / "annots.csv"
+    csv.write_text("type,onset,duration\nBAD,1.0,0.5\nGOOD,2.0,0.5\nBAD,5.0,1.0\n")
+    types, _ = get_annotation_types_from_file(csv)
+    assert types == ["BAD", "GOOD"]
+
+
+def test_get_annotation_types_from_file_two_column_returns_none(tmp_path):
+    """Returns None for a file with no type column (onset,duration header)."""
+    csv = tmp_path / "no_type.csv"
+    csv.write_text("onset,duration\n1.0,0.5\n2.0,1.0\n")
+    types, _ = get_annotation_types_from_file(csv)
+    assert types is None
+
+
+# --- integer-value detection ---
+
+
+def test_check_annotation_values_are_integer_all_integers(tmp_path):
+    """Returns True when all onset/duration values are whole numbers."""
+    csv = tmp_path / "annots.csv"
+    csv.write_text("type,onset,duration\nBAD,256,128\nBAD,512,64\n")
+    _, values_are_integer = get_annotation_types_from_file(csv)
+    assert values_are_integer is True
+
+
+def test_check_annotation_values_are_integer_float_integers(tmp_path):
+    """Returns True when values are float-encoded whole numbers (e.g. 256.0)."""
+    csv = tmp_path / "annots.csv"
+    csv.write_text("type,onset,duration\nBAD,256.0,128.0\n")
+    _, values_are_integer = get_annotation_types_from_file(csv)
+    assert values_are_integer is True
+
+
+def test_check_annotation_values_are_integer_has_fractions(tmp_path):
+    """Returns False when any value has a fractional part."""
+    csv = tmp_path / "annots.csv"
+    csv.write_text("type,onset,duration\nBAD,1.5,0.5\n")
+    _, values_are_integer = get_annotation_types_from_file(csv)
+    assert values_are_integer is False
+
+
+def test_check_annotation_values_are_integer_two_column(tmp_path):
+    """Works with two-column (onset,duration) files."""
+    csv = tmp_path / "no_type.csv"
+    csv.write_text("onset,duration\n100,50\n200,25\n")
+    _, values_are_integer = get_annotation_types_from_file(csv)
+    assert values_are_integer is True
+
+
+def test_check_annotation_values_are_integer_empty_file(tmp_path):
+    """Returns False when the file has no data rows."""
+    csv = tmp_path / "empty.csv"
+    csv.write_text("type,onset,duration\n")
+    _, values_are_integer = get_annotation_types_from_file(csv)
+    assert values_are_integer is False


### PR DESCRIPTION
This adds functionality for

- importing annotations from a file without a "type" column (we then assume all annotations have the same type)
- importing annotations from a file where all onset and duration values are in samples