### PR TITLE
Fix sidebar background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] · YYYY-MM-DD
+### 🔧 Fixed
+- Fix the sidebar background color on Windows and Linux ([#622](https://github.com/cbrnr/mnelab/pull/622) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.4.4] · 2026-04-21
 ### ✨ Added

--- a/src/mnelab/widgets/sidebar.py
+++ b/src/mnelab/widgets/sidebar.py
@@ -108,7 +108,7 @@ class SidebarTableWidget(QTableWidget):
         if sys.platform != "darwin":
             # disable cell style changes upon focusing (clicking); not needed on macOS
             self.setStyleSheet("""
-                QTableWidget#sidebar { outline: 0; }
+                QTableWidget#sidebar { outline: 0; background: palette(base); }
                 QTableWidget#sidebar::item:hover {
                     background: transparent;
                     color: palette(text);


### PR DESCRIPTION
At least on KDE, the sidebar background sometimes wouldn't follow the theme. This PR should fix this issue, although KDE seems to have trouble syncing the theme (e.g., when the system theme is set to dark and MNELAB is set to light, the sidebar background is sometimes still dark, e.g. when the MNELAB window is defocussed).