### PR TITLE
Make manual theme switching more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### 🔧 Fixed
 - Fix the sidebar background color on Windows and Linux ([#622](https://github.com/cbrnr/mnelab/pull/622) and [#623](https://github.com/cbrnr/mnelab/pull/623) by [Clemens Brunner](https://github.com/cbrnr))
-
-### 🗑️ Removed
-- Remove manual Light/Dark theme options as this did not work reliably; the app now always follows the system theme ([#623](https://github.com/cbrnr/mnelab/pull/623) by [Clemens Brunner](https://github.com/cbrnr))
+- Make manual theme selection more robust ([#630](https://github.com/cbrnr/mnelab/pull/630) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.4.4] · 2026-04-21
 ### ✨ Added

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -56,7 +56,7 @@ from mnelab.io.npy import parse_npy
 from mnelab.io.readers import read_raw, split_name_ext
 from mnelab.io.xdf import get_xml, list_chunks
 from mnelab.model import InvalidAnnotationsError, LabelsNotFoundError, Model
-from mnelab.settings import SettingsDialog, read_settings, write_settings
+from mnelab.settings import SettingsDialog, apply_theme, read_settings, write_settings
 from mnelab.utils import (
     annotations_between_events,
     count_locations,
@@ -149,8 +149,11 @@ class MainWindow(QMainWindow):
             [f"{Path(__file__).parent}/icons"] + QIcon.themeSearchPaths()
         )
         QIcon.setFallbackThemeName("light")
-        # some styles do not emit PaletteChange on startup
-        QApplication.sendEvent(self, QEvent(QEvent.Type.PaletteChange))
+        apply_theme(settings["theme"])
+        # for "Auto", setColorScheme(Unknown) is the Qt default and may not fire
+        # PaletteChange, so send it manually to initialize the icon theme
+        if settings["theme"] == "Auto":
+            QApplication.sendEvent(self, QEvent(QEvent.Type.PaletteChange))
 
         self.all_actions = {}  # contains all actions
 
@@ -1793,16 +1796,20 @@ class MainWindow(QMainWindow):
     def settings(self):
         old_backend = read_settings("plot_backend")
         old_badges = read_settings("dtype_badges")
+        old_theme = read_settings("theme")
         old_menu_icons = read_settings("menu_icons")
         SettingsDialog(self, self.plot_backends).exec()
         new_backend = read_settings("plot_backend")
         new_badges = read_settings("dtype_badges")
+        new_theme = read_settings("theme")
         new_menu_icons = read_settings("menu_icons")
         if old_backend != new_backend:
             mne.viz.set_browser_backend(new_backend)
             self.model.history.append(f'mne.viz.set_browser_backend("{new_backend}")')
         if old_badges != new_badges:
             self.sidebar.set_badges_visible(new_badges)
+        if old_theme != new_theme:
+            apply_theme(new_theme)
         if old_menu_icons != new_menu_icons:
             QMessageBox.information(
                 self,
@@ -1959,11 +1966,15 @@ class MainWindow(QMainWindow):
                 print(format_code("\n".join(self.model.history)))
             event.accept()
         elif event.type() == QEvent.Type.PaletteChange:
-            color_scheme = QApplication.styleHints().colorScheme()
-            if color_scheme != Qt.ColorScheme.Unknown:
-                QIcon.setThemeName(color_scheme.name.lower())
+            theme = read_settings("theme")
+            if theme in ("Light", "Dark"):
+                QIcon.setThemeName(theme.lower())
             else:
-                QIcon.setThemeName("light")  # fallback
+                color_scheme = QApplication.styleHints().colorScheme()
+                if color_scheme != Qt.ColorScheme.Unknown:
+                    QIcon.setThemeName(color_scheme.name.lower())
+                else:
+                    QIcon.setThemeName("light")  # fallback
             if hasattr(self, "sidebar"):
                 self.sidebar.refresh_theme()
         elif event.type() == QEvent.Type.DragEnter:

--- a/src/mnelab/settings.py
+++ b/src/mnelab/settings.py
@@ -14,7 +14,7 @@ from PySide6.QtCore import (
     QUrl,
     Slot,
 )
-from PySide6.QtGui import QDesktopServices, Qt
+from PySide6.QtGui import QDesktopServices, QGuiApplication, Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -52,6 +52,7 @@ _DEFAULTS = {
     "dtype_badges": True,
     "menu_icons": True,
     "show_menubar": True,
+    "theme": "Auto",
     "annotation_colors": {},
 }
 
@@ -109,6 +110,24 @@ def clear_settings():
     QSettings(SETTINGS_PATH, QSettings.Format.IniFormat).clear()
 
 
+def apply_theme(theme):
+    """Apply a color scheme to the application.
+
+    Parameters
+    ----------
+    theme : str
+        One of `"Auto"`, `"Light"`, or `"Dark"`.
+    """
+    mapping = {
+        "Auto": Qt.ColorScheme.Unknown,
+        "Light": Qt.ColorScheme.Light,
+        "Dark": Qt.ColorScheme.Dark,
+    }
+    QGuiApplication.styleHints().setColorScheme(
+        mapping.get(theme, Qt.ColorScheme.Unknown)
+    )
+
+
 class SettingsDialog(QDialog):
     def __init__(self, parent, backends):
         super().__init__(parent)
@@ -118,6 +137,15 @@ class SettingsDialog(QDialog):
         form = QFormLayout()
         form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.FieldsStayAtSizeHint)
         form.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+
+        themes = ["Auto", "Light", "Dark"]
+        theme = read_settings("theme")
+        if theme not in themes:
+            theme = _DEFAULTS["theme"]
+        self.theme = QComboBox()
+        self.theme.addItems(themes)
+        self.theme.setCurrentIndex(themes.index(theme))
+        form.addRow("Theme:", self.theme)
 
         backend = read_settings("plot_backend")
         if backend not in backends:
@@ -206,6 +234,7 @@ class SettingsDialog(QDialog):
             plot_backend=self.plot_backend.currentText(),
             dtype_badges=self.dtype_badges.isChecked(),
             menu_icons=self.menu_icons.isChecked(),
+            theme=self.theme.currentText(),
         )
         self.parent().recent = self.parent().recent[: read_settings("max_recent")]
         self.accept()
@@ -217,6 +246,7 @@ class SettingsDialog(QDialog):
         self.duration.setValue(_DEFAULTS["duration"])
         self.dtype_badges.setChecked(_DEFAULTS["dtype_badges"])
         self.menu_icons.setChecked(_DEFAULTS["menu_icons"])
+        self.theme.setCurrentIndex(self.theme.findText(_DEFAULTS["theme"]))
         self.plot_backend.setCurrentIndex(
             self.plot_backend.findText(_DEFAULTS["plot_backend"])
         )


### PR DESCRIPTION
This should now work more reliably, but I still need to test this on all three platforms.

- [ ] Linux (KDE)
- [x] macOS ([standalone](https://github.com/cbrnr/mnelab/actions/runs/25661039311/artifacts/6914632901))
- [x] Windows ([standalone](https://github.com/cbrnr/mnelab/actions/runs/25661039311/artifacts/6914627368))

Testing should include:

- "Auto" should follow system theme changes
- "Light" should always use the light theme independent of the system theme
- "Dark" should always use the dark theme independent of the system theme

It is OK if the titlebar keeps following the system theme, but the palette and icons must adapt. Also, sometimes there seems to be some hiccups where restarting MNELAB resolves any issues; this is also OK.

On Linux/KDE, manual theme switching only works if using the Fusion theme. It does not work when using the Breeze theme, which is the default KDE theme, and in which case the MNELAB theme always follows the system theme ("Auto"). There are three options:

1. **Do nothing** — accept it as a platform limitation. The app still follows the system theme correctly (via `PaletteChange`), which is what most KDE users expect anyway. The option to manually set the theme should then probably be removed from Settings on this platform.
2. **Switch to the Fusion style** — `QApplication.setStyle("Fusion")` respects `setColorScheme()`, but it looks nothing like Breeze.
3. **Apply a full `QPalette` manually** — instead of calling `setColorScheme()`, construct and apply a complete light or dark `QPalette` directly on the `QApplication`. This bypasses the KDE platform theme's color management entirely. It's the most robust approach but requires defining all palette colors.