### PR TITLE
Fix hamburger menu style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix the sidebar background color on Windows and Linux ([#622](https://github.com/cbrnr/mnelab/pull/622) and [#623](https://github.com/cbrnr/mnelab/pull/623) by [Clemens Brunner](https://github.com/cbrnr))
 - Improve history syntax highlighting in dark mode ([#631](https://github.com/cbrnr/mnelab/pull/631) by [Clemens Brunner](https://github.com/cbrnr))
 - Fix "Menubar" checkbox icon ([#634](https://github.com/cbrnr/mnelab/pull/634) by [Clemens Brunner](https://github.com/cbrnr))
+- Fix hamburger menu style ([#635](https://github.com/cbrnr/mnelab/pull/635) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### 🗑️ Removed
 - Remove manual Light/Dark theme options as this did not work reliably; the app now always follows the system theme ([#623](https://github.com/cbrnr/mnelab/pull/623) by [Clemens Brunner](https://github.com/cbrnr))

--- a/src/mnelab/dialogs/history.py
+++ b/src/mnelab/dialogs/history.py
@@ -33,7 +33,7 @@ class HistoryDialog(QDialog):
         if sys.platform.startswith("darwin"):
             fontname = "menlo"
         elif sys.platform.startswith("win32"):
-            fontname = "consolas"
+            fontname = "Cascadia Mono"
         else:
             fontname = "monospace"
         font.setFamily(fontname)

--- a/src/mnelab/dialogs/history.py
+++ b/src/mnelab/dialogs/history.py
@@ -2,11 +2,10 @@
 #
 # License: BSD (3-clause)
 
-import sys
 from datetime import datetime
 from pathlib import Path
 
-from PySide6.QtGui import QFont, QGuiApplication
+from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -17,7 +16,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from mnelab.utils import CodeEditor, PythonHighlighter, format_code
+from mnelab.utils import CodeEditor, PythonHighlighter, format_code, monospace_font
 
 
 class HistoryDialog(QDialog):
@@ -29,15 +28,7 @@ class HistoryDialog(QDialog):
         self.history = format_code("\n".join(history))
         self.log = "\n".join(log)
 
-        font = QFont()
-        if sys.platform.startswith("darwin"):
-            fontname = "menlo"
-        elif sys.platform.startswith("win32"):
-            fontname = "Cascadia Mono"
-        else:
-            fontname = "monospace"
-        font.setFamily(fontname)
-        font.setStyleHint(QFont.StyleHint.Monospace)
+        font = monospace_font()
 
         history_text = CodeEditor()
         history_text.setFont(font)

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -36,11 +36,9 @@ from PySide6.QtWidgets import (
     QMainWindow,
     QMenu,
     QMessageBox,
-    QProxyStyle,
     QSizePolicy,
     QSplitter,
     QStackedWidget,
-    QStyle,
     QTableWidgetItem,
     QToolButton,
     QWidget,
@@ -75,16 +73,6 @@ from mnelab.viz import (
     plot_evoked_topomaps,
 )
 from mnelab.widgets import EmptyWidget, InfoWidget, SidebarTableWidget
-
-
-class MenuPaddingStyle(QProxyStyle):
-    def sizeFromContents(self, contents_type, option, size, widget=None):
-        base_size = super().sizeFromContents(contents_type, option, size, widget)
-
-        if contents_type == QStyle.ContentsType.CT_MenuItem:
-            base_size.setWidth(base_size.width() + 30)  # increase width
-
-        return base_size
 
 
 class _MNELogHandler(logging.Handler):
@@ -512,8 +500,6 @@ class MainWindow(QMainWindow):
             self._hamburger_button.setIcon(QIcon.fromTheme("hamburger-menu"))
             self._hamburger_button.setToolTip("Menu")
             hamburger_popup = QMenu(self)
-            self._menu_style = MenuPaddingStyle()
-            hamburger_popup.setStyle(self._menu_style)
             for menu_action in self.menuBar().actions():
                 if (submenu := menu_action.menu()) is not None:
                     hamburger_popup.addMenu(submenu)

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -503,6 +503,13 @@ class MainWindow(QMainWindow):
             for menu_action in self.menuBar().actions():
                 if (submenu := menu_action.menu()) is not None:
                     hamburger_popup.addMenu(submenu)
+            hamburger_popup.addSeparator()
+            _hamburger_settings = hamburger_popup.addAction(
+                QIcon.fromTheme("settings"), "Settings...", self.settings
+            )
+            _hamburger_settings.setShortcut(
+                QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_Comma)
+            )
             self._hamburger_button.setMenu(hamburger_popup)
             self._hamburger_button.setPopupMode(
                 QToolButton.ToolButtonPopupMode.InstantPopup
@@ -513,6 +520,7 @@ class MainWindow(QMainWindow):
             self._hamburger_action.setVisible(hamburger_enabled)
             self.menuBar().setVisible(not hamburger_enabled)
             self.all_actions["menubar"].setChecked(not hamburger_enabled)
+            self.all_actions["settings"].setVisible(not hamburger_enabled)
         self.setUnifiedTitleAndToolBarOnMac(True)
         if sys.platform == "darwin":
             self.toolbar.setStyleSheet("""
@@ -1915,6 +1923,7 @@ class MainWindow(QMainWindow):
         self._hamburger_spacer_action.setVisible(hamburger_enabled)
         self._hamburger_action.setVisible(hamburger_enabled)
         self.all_actions["menubar"].setChecked(not menubar_visible)
+        self.all_actions["settings"].setVisible(not hamburger_enabled)
         write_settings(show_menubar=not hamburger_enabled)
 
     @Slot()

--- a/src/mnelab/utils/__init__.py
+++ b/src/mnelab/utils/__init__.py
@@ -19,5 +19,6 @@ from mnelab.utils.utils import (
     get_annotation_types_from_file,
     image_path,
     merge_annotations,
+    monospace_font,
     natural_sort,
 )

--- a/src/mnelab/utils/utils.py
+++ b/src/mnelab/utils/utils.py
@@ -3,6 +3,7 @@
 # License: BSD (3-clause)
 
 import re
+import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,6 +13,7 @@ import numpy as np
 from mne import channel_type
 from mne.channels import DigMontage
 from mne.defaults import _handle_default
+from PySide6.QtGui import QFont
 
 
 def count_locations(info):
@@ -24,6 +26,23 @@ def image_path(fname):
     """Return absolute path to image fname."""
     root = Path(__file__).parent.parent
     return str((root / "images" / Path(fname)).resolve())
+
+
+def monospace_font():
+    """Return a QFont configured for monospace display.
+
+    Selects the preferred platform monospace font with a `Monospace` style hint as
+    fallback.
+    """
+    font = QFont()
+    if sys.platform.startswith("darwin"):
+        font.setFamily("Menlo")
+    elif sys.platform.startswith("win32"):
+        font.setFamily("Cascadia Mono")
+    else:
+        font.setFamily("monospace")
+    font.setStyleHint(QFont.StyleHint.Monospace)
+    return font
 
 
 def natural_sort(lst):

--- a/src/mnelab/widgets/infowidget.py
+++ b/src/mnelab/widgets/infowidget.py
@@ -24,7 +24,7 @@ dev_label = (
 def _make_shortcuts_table(actions):
     dark = QGuiApplication.styleHints().colorScheme() == Qt.ColorScheme.Dark
     text_color = "#999" if dark else "#777"
-    kbd_bg = "#2a2a2a" if dark else "#e2e2e2"
+    kbd_bg = "#3a3a3a" if dark else "#e2e2e2"
     kbd_font = '"Cascadia Mono", ' if sys.platform.startswith("win32") else ""
     html = f"""<!DOCTYPE html>
     <html>

--- a/src/mnelab/widgets/infowidget.py
+++ b/src/mnelab/widgets/infowidget.py
@@ -2,9 +2,10 @@
 #
 # License: BSD (3-clause)
 
+import sys
 from pathlib import Path
 
-from PySide6.QtCore import QEvent, QTimer
+from PySide6.QtCore import QEvent, Qt, QTimer
 from PySide6.QtGui import QGuiApplication, QIcon, QKeySequence
 from PySide6.QtWidgets import (
     QGridLayout,
@@ -21,15 +22,22 @@ dev_label = (
 
 
 def _make_shortcuts_table(actions):
-    text_color = "#777"
+    dark = QGuiApplication.styleHints().colorScheme() == Qt.ColorScheme.Dark
+    text_color = "#999" if dark else "#777"
+    kbd_bg = "#2a2a2a" if dark else "#e2e2e2"
+    kbd_font = '"Cascadia Mono", ' if sys.platform.startswith("win32") else ""
     html = f"""<!DOCTYPE html>
     <html>
       <head>
         <style>
           html {{ font-size: 16px; }}
-          kbd {{
+          body {{ margin-left: 8px; margin-right: 8px; }}
+          span {{
+            font-family: {kbd_font}monospace;
+            font-size: 0.8em;
             font-weight: 600;
             color: {text_color};
+            background-color: {kbd_bg};
           }}
           table {{ color: {text_color}; }}
         </style>
@@ -45,10 +53,10 @@ def _make_shortcuts_table(actions):
         modifier, key = shortcut[:-1].strip(), shortcut[-1]
         html += f'\n            <tr><td align="right" width="50%">{name} </td>'
         if modifier[-1] == "+":
-            html += f"<td><kbd>{modifier[:-1]}</kbd>+"
+            html += f"<td><span>&nbsp;{modifier[:-1]}&nbsp;</span>+"
         else:
-            html += f"<td><kbd>{modifier}</kbd> "
-        html += f"<kbd>{key}</kbd></td></tr>"
+            html += f"<td><span>&nbsp;{modifier}&nbsp;</span> "
+        html += f"<span>&nbsp;{key}&nbsp;</span></td></tr>"
     html += """\n          </tbody>
         </table>
       </body>
@@ -179,10 +187,16 @@ class EmptyWidget(QWidget):
         from mnelab import IS_DEV_VERSION
 
         super().__init__()
-        text = QLabel(_make_shortcuts_table(actions))
+        self._actions = actions
+        self._label = QLabel(_make_shortcuts_table(actions))
         vbox = QVBoxLayout(self)
         vbox.addStretch()
-        vbox.addWidget(text)
+        vbox.addWidget(self._label)
         vbox.addStretch()
         if IS_DEV_VERSION:
             vbox.addWidget(QLabel(dev_label))
+
+    def changeEvent(self, event):
+        if event.type() == QEvent.Type.PaletteChange:
+            self._label.setText(_make_shortcuts_table(self._actions))
+        super().changeEvent(event)

--- a/src/mnelab/widgets/infowidget.py
+++ b/src/mnelab/widgets/infowidget.py
@@ -2,7 +2,6 @@
 #
 # License: BSD (3-clause)
 
-import sys
 from pathlib import Path
 
 from PySide6.QtCore import QEvent, Qt, QTimer
@@ -16,6 +15,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from mnelab.utils import monospace_font
+
 dev_label = (
     '<p align="right"><font color="red"><small>Development Version</small></font></p>'
 )
@@ -25,7 +26,8 @@ def _make_shortcuts_table(actions):
     dark = QGuiApplication.styleHints().colorScheme() == Qt.ColorScheme.Dark
     text_color = "#999" if dark else "#777"
     kbd_bg = "#3a3a3a" if dark else "#e2e2e2"
-    kbd_font = '"Cascadia Mono", ' if sys.platform.startswith("win32") else ""
+    font_family = monospace_font().family()
+    kbd_font = f'"{font_family}", ' if font_family != "monospace" else ""
     html = f"""<!DOCTYPE html>
     <html>
       <head>


### PR DESCRIPTION
Also use Cascadia Mono on Windows for monospace fonts and better kbd style. Also fix hamburger menu style (background and highlight from system theme).

Looks good on:

- [x] Windows
- [x] Linux (KDE) (works with Fusion but not with Breeze style, where right arrows overlap the menu text, see screenshot below)
- [x] macOS

<img width="977" height="723" alt="image" src="https://github.com/user-attachments/assets/6387cb4b-e5f9-4bff-8c0b-068c0f3a41dc" />