### PR TITLE
Implement tree-based sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix sorting in the "Channel Statistics" dialog ([#640](https://github.com/cbrnr/mnelab/pull/640) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### 🌀 Changed
+- Switch to a tree-based sidebar ([#643](https://github.com/cbrnr/mnelab/pull/643) by [Clemens Brunner](https://github.com/cbrnr))
 - Improve table header alignment across various dialogs ([#640](https://github.com/cbrnr/mnelab/pull/640) by [Clemens Brunner](https://github.com/cbrnr))
 - Title-case all dialog titles and labels ([#641](https://github.com/cbrnr/mnelab/pull/641) by [Clemens Brunner](https://github.com/cbrnr))
 

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -21,7 +21,6 @@ from pybvrf import read_bvrf_header
 from PySide6.QtCore import (
     QEvent,
     QMetaObject,
-    QModelIndex,
     Qt,
     QTimer,
     QUrl,
@@ -39,8 +38,8 @@ from PySide6.QtWidgets import (
     QSizePolicy,
     QSplitter,
     QStackedWidget,
-    QTableWidgetItem,
     QToolButton,
+    QTreeWidgetItem,
     QWidget,
 )
 from pyxdf import resolve_streams
@@ -72,7 +71,7 @@ from mnelab.viz import (
     plot_evoked_comparison,
     plot_evoked_topomaps,
 )
-from mnelab.widgets import EmptyWidget, InfoWidget, SidebarTableWidget
+from mnelab.widgets import EmptyWidget, InfoWidget, SidebarTreeWidget
 
 SIDEBAR_MIN_WIDTH = 150
 INFOWIDGET_MIN_WIDTH = 200
@@ -539,14 +538,11 @@ class MainWindow(QMainWindow):
             self.all_actions["toolbar"].setChecked(False)
 
         # set up data model for sidebar (list of open files)
-        self.sidebar = SidebarTableWidget(self)
+        self.sidebar = SidebarTreeWidget(self)
         self.sidebar.setMinimumWidth(SIDEBAR_MIN_WIDTH)
         self.sidebar.hide()
-        self.sidebar.rowsMoved.connect(self._sidebar_move_event)
-        self.sidebar.itemDelegate().commitData.connect(self._sidebar_edit_event)
-        self.sidebar.currentCellChanged.connect(
-            lambda row, col, *_: self._update_data(row, col)
-        )
+        self.sidebar.itemChanged.connect(self._sidebar_item_changed)
+        self.sidebar.currentItemChanged.connect(lambda cur, _: self._update_data(cur))
 
         self.splitter = QSplitter()
         self.splitter.setObjectName("main_splitter")
@@ -588,35 +584,22 @@ class MainWindow(QMainWindow):
         print(traceback_text, file=sys.stderr)
         ErrorMessageBox(self, exception_text, "", traceback_text).show()
 
-    def _sidebar_edit_event(self, edit):
+    def _sidebar_item_changed(self, item, column):
         """
-        Triggered when a data set in the sidebar is renamed.
+        Triggered when a tree item's data changes (e.g. after inline name editing).
 
         Parameters
         ----------
-        edit : PySide6.QtWidgets.QLineEdit
-            The text editor.
+        item : PySide6.QtWidgets.QTreeWidgetItem
+            The item that changed.
+        column : int
+            The column that changed.
         """
-        self.model.current["name"] = edit.text()
-
-    def _sidebar_move_event(self, from_row, to_row):
-        """
-        Triggered when an item in the sidebar is moved.
-
-        Parameters
-        ----------
-        parent : PySide6.QtCore.QModelIndex
-            Unused.
-        start : int
-            The source index of the item.
-        end : int
-            Unused (equals start as the sidebar only allows single selection).
-        destination : PySide6.QtCore.QModelIndex
-            Unused.
-        row : int
-            The target index.
-        """
-        self.model.move_data(from_row, to_row)
+        if column == 0:
+            dataset_id = item.data(0, Qt.ItemDataRole.UserRole)
+            index = self.model.find_index_by_id(dataset_id)
+            if index >= 0:
+                self.model.data[index]["name"] = item.text(0)
 
     @contextmanager
     def _wait_cursor(self):
@@ -635,28 +618,27 @@ class MainWindow(QMainWindow):
         # update sidebar
         if len(self.model.data) > 0:
             self.sidebar.show()
-            # block signals during rebuild: setRowCount(0) would otherwise
-            # emit currentCellChanged with row=-1, corrupting model.index
+            # block signals during rebuild to prevent spurious currentItemChanged /
+            # itemChanged callbacks that would corrupt model.index or dataset names
             self.sidebar.blockSignals(True)
-            self.sidebar.setRowCount(0)
-            self.sidebar.setRowCount(len(self.model.names))
-            self.sidebar.setColumnCount(4)
-
-            for row_index, name in enumerate(self.model.names):
-                item_index = QTableWidgetItem(str(row_index + 1))
-                self.sidebar.setItem(row_index, 0, item_index)
-
-                item_name = QTableWidgetItem(name)
-                item_name.setFlags(item_name.flags() | Qt.ItemFlag.ItemIsEditable)
-                self.sidebar.setItem(row_index, 1, item_name)
-
-                dtype = self.model.data[row_index]["dtype"] or ""
-                self.sidebar.set_dtype(row_index, dtype)
-
-            self.sidebar.style_rows()
+            self.sidebar.clear()
+            id_to_item = {}
+            for dataset in self.model.data:
+                item = self.sidebar.make_item(dataset["name"], dataset["id"])
+                self.sidebar.set_dtype(item, dataset["dtype"] or "")
+                parent_id = dataset["parent_id"]
+                if parent_id is not None and parent_id in id_to_item:
+                    id_to_item[parent_id].addChild(item)
+                else:
+                    self.sidebar.addTopLevelItem(item)
+                id_to_item[dataset["id"]] = item
+            self.sidebar.expandAll()
             self.sidebar.set_badges_visible(read_settings("dtype_badges"))
-            self.sidebar.selectRow(self.model.index)
+            current_id = self.model.data[self.model.index]["id"]
+            if current_id in id_to_item:
+                self.sidebar.setCurrentItem(id_to_item[current_id])
             self.sidebar.blockSignals(False)
+            self.sidebar.style_items()
             self.sidebar.setFocus()
         else:
             self.sidebar.hide()
@@ -1894,17 +1876,21 @@ class MainWindow(QMainWindow):
             if not self.recent:
                 self.recent_menu.setEnabled(False)
 
-    @Slot(QModelIndex)
-    def _update_data(self, row, column):
-        """Update index and information based on the state of the sidebar.
+    @Slot(QTreeWidgetItem)
+    def _update_data(self, item):
+        """Update index and information based on the selected sidebar item.
 
         Parameters
         ----------
-        selected : QModelIndex
-            Index of the selected row.
+        item : PySide6.QtWidgets.QTreeWidgetItem
+            The newly selected tree item.
         """
-        if row != self.model.index:
-            self.model.index = row
+        if item is None:
+            return
+        dataset_id = item.data(0, Qt.ItemDataRole.UserRole)
+        new_index = self.model.find_index_by_id(dataset_id)
+        if new_index != self.model.index:
+            self.model.index = new_index
             self.data_changed()
             self.model.history.append(f"data = datasets[{self.model.index}]")
 

--- a/src/mnelab/model.py
+++ b/src/mnelab/model.py
@@ -51,6 +51,7 @@ class Model:
         self.view = None  # current view
         self.data = []  # list of data sets
         self.index = -1  # index of currently active data set
+        self._next_id = 1  # monotonically increasing dataset ID counter
         self.log = []  # captured MNE log messages
         self.history = [
             "from copy import deepcopy",
@@ -69,8 +70,11 @@ class Model:
         ]
 
     @data_changed
-    def insert_data(self, dataset):
+    def insert_data(self, dataset, parent_id=None):
         """Insert data set after current index."""
+        dataset["id"] = self._next_id
+        dataset["parent_id"] = parent_id
+        self._next_id += 1
         self.index += 1
         self.data.insert(self.index, dataset)
         self.history.append(f"datasets.insert({self.index}, data)")
@@ -95,7 +99,8 @@ class Model:
     @data_changed
     def duplicate_data(self):
         """Duplicate current data set."""
-        self.insert_data(deepcopy(self.current))
+        parent_id = self.current["id"]
+        self.insert_data(deepcopy(self.current), parent_id=parent_id)
         self.history[-1] = self.history[-1][:-5] + "deepcopy(data))"
         self.history.append(f"data = datasets[{self.index}]")
         self.current["fname"] = None
@@ -125,6 +130,47 @@ class Model:
     def __len__(self):
         """Return number of data sets."""
         return len(self.data)
+
+    def find_index_by_id(self, dataset_id):
+        """Return the list index of the dataset with the given stable ID."""
+        for i, dataset in enumerate(self.data):
+            if dataset["id"] == dataset_id:
+                return i
+        return -1
+
+    def find_descendants(self, dataset_id):
+        """Return all datasets that are direct or indirect children of dataset_id."""
+        descendants = []
+        queue = [dataset_id]
+        while queue:
+            cur = queue.pop(0)
+            for ds in self.data:
+                if ds["parent_id"] == cur:
+                    descendants.append(ds)
+                    queue.append(ds["id"])
+        return descendants
+
+    @data_changed
+    def remove_data_cascade(self, dataset_id):
+        """Remove a dataset and all its descendants."""
+        ids_to_remove = set()
+        queue = [dataset_id]
+        while queue:
+            cur = queue.pop(0)
+            ids_to_remove.add(cur)
+            for ds in self.data:
+                if ds["parent_id"] == cur:
+                    queue.append(ds["id"])
+        # remove from highest index to lowest to keep earlier indices valid
+        indices = sorted(
+            [i for i, ds in enumerate(self.data) if ds["id"] in ids_to_remove],
+            reverse=True,
+        )
+        for i in indices:
+            self.data.pop(i)
+            self.history.append(f"datasets.pop({i})")
+        if self.index >= len(self.data):
+            self.index = len(self.data) - 1
 
     @data_changed
     def load_data(self, data, fname, name=None):

--- a/src/mnelab/model.py
+++ b/src/mnelab/model.py
@@ -158,9 +158,7 @@ class Model:
         while queue:
             cur = queue.pop(0)
             ids_to_remove.add(cur)
-            for ds in self.data:
-                if ds["parent_id"] == cur:
-                    queue.append(ds["id"])
+            queue.extend(ds["id"] for ds in self.data if ds["parent_id"] == cur)
         # remove from highest index to lowest to keep earlier indices valid
         indices = sorted(
             [i for i, ds in enumerate(self.data) if ds["id"] in ids_to_remove],

--- a/src/mnelab/widgets/__init__.py
+++ b/src/mnelab/widgets/__init__.py
@@ -3,5 +3,5 @@
 # License: BSD (3-clause)
 
 from mnelab.widgets.infowidget import EmptyWidget, InfoWidget
-from mnelab.widgets.sidebar import SidebarTableWidget
+from mnelab.widgets.sidebar import SidebarTreeWidget
 from mnelab.widgets.spinbox import FlatDoubleSpinBox, FlatSpinBox

--- a/src/mnelab/widgets/sidebar.py
+++ b/src/mnelab/widgets/sidebar.py
@@ -4,17 +4,17 @@
 
 import sys
 
-from PySide6.QtCore import QEvent, QRect, QRectF, Qt, Signal
+from PySide6.QtCore import QEvent, QRectF, QSize, Qt
 from PySide6.QtGui import QColor, QCursor, QIcon, QPainter, QPalette
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QApplication,
-    QFrame,
     QHeaderView,
+    QMessageBox,
     QStyledItemDelegate,
-    QTableWidget,
-    QTableWidgetItem,
     QToolButton,
+    QTreeWidget,
+    QTreeWidgetItem,
 )
 
 ROW_HEIGHT = 30
@@ -30,6 +30,9 @@ class TypeBadgeDelegate(QStyledItemDelegate):
     """Renders a rounded-rectangle badge for the data type column."""
 
     def paint(self, painter, option, index):
+        # draw selection/hover background first (without the text to avoid flicker)
+        super().paint(painter, option, index)
+
         dtype = index.data(Qt.ItemDataRole.DisplayRole)
         if not dtype:
             return
@@ -66,76 +69,39 @@ class TypeBadgeDelegate(QStyledItemDelegate):
         hint.setWidth(56)
         return hint
 
-
-class SpanningHeaderView(QHeaderView):
-    """Horizontal header where a contiguous range of sections is painted as one."""
-
-    def __init__(self, orientation, span_start=0, span_count=1, parent=None):
-        super().__init__(orientation, parent)
-        self._span_start = span_start
-        self._span_count = span_count
-
-    def paintSection(self, painter, rect, logical_index):
-        span_cols = range(self._span_start, self._span_start + self._span_count)
-        if logical_index in span_cols and logical_index != self._span_start:
-            return
-        if logical_index == self._span_start:
-            total_width = sum(
-                self.sectionSize(self._span_start + i) for i in range(self._span_count)
-            )
-            rect = QRect(rect.x(), rect.y(), total_width, rect.height())
-        super().paintSection(painter, rect, logical_index)
+    def createEditor(self, parent, option, index):
+        return None  # badge column is not editable
 
 
-class SidebarTableWidget(QTableWidget):
-    rowsMoved = Signal(int, int)  # custom signal emitted when drag-and-dropping rows
-
+class SidebarTreeWidget(QTreeWidget):
     def __init__(self, parent):
         super().__init__(parent)
         self.parent = parent
-        self.setDragEnabled(True)
-        self.setAcceptDrops(True)
-        self.setDragDropMode(QAbstractItemView.DragDropMode.InternalMove)
+        self.setColumnCount(3)
+        self.setHeaderHidden(True)
         self.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
-        self.setDefaultDropAction(Qt.DropAction.MoveAction)
-        self.setDropIndicatorShown(False)
-        self.setDragDropOverwriteMode(False)
-        self.setFrameStyle(QFrame.Shape.NoFrame)
         self.setEditTriggers(QAbstractItemView.EditTrigger.DoubleClicked)
+        self.setUniformRowHeights(True)
         self.setObjectName("sidebar")
-        self.setColumnCount(4)
-        self.setShowGrid(False)
-        if sys.platform != "darwin":
-            self._apply_base_stylesheet()
-        self.drop_row = -1
-
-        header = SpanningHeaderView(
-            Qt.Orientation.Horizontal, span_start=1, span_count=3, parent=self
-        )
-        self.setHorizontalHeader(header)
-        self.setHorizontalHeaderLabels(["#", "Dataset", "", ""])
-        self.horizontalHeaderItem(0).setTextAlignment(
-            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
-        )
-        self.horizontalHeaderItem(1).setTextAlignment(
-            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
-        )
-        self.verticalHeader().hide()
-        self.horizontalHeader().setStretchLastSection(False)
-        self.horizontalHeader().setMinimumSectionSize(0)
-        self.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)
-        self.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
-        self.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Fixed)
-        self.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.Fixed)
-        self.setColumnWidth(2, 56)
-        self.setColumnWidth(3, 28)
-        self.resizeColumnToContents(0)
-        self.setItemDelegateForColumn(2, TypeBadgeDelegate(self))
-        self.horizontalHeader().hide()
-        self.setAccessibleName("Opened datasets")
         self.setMouseTracking(True)
         self.setTabKeyNavigation(False)
+        # prevent double-click from toggling expand/collapse so it can trigger editing
+        self.setExpandsOnDoubleClick(False)
+        self.setIndentation(16)
+        self.setDragEnabled(False)
+        self.setAcceptDrops(True)
+        self.header().setStretchLastSection(False)
+        self.header().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        self.header().setSectionResizeMode(1, QHeaderView.ResizeMode.Fixed)
+        self.header().setSectionResizeMode(2, QHeaderView.ResizeMode.Fixed)
+        self.header().setMinimumSectionSize(0)
+        self.setColumnWidth(1, 56)
+        self.setColumnWidth(2, 28)
+        self.setItemDelegateForColumn(1, TypeBadgeDelegate(self))
+        self.setAccessibleName("Opened datasets")
+        self._dragging = False
+        if sys.platform != "darwin":
+            self._apply_base_stylesheet()
         self.viewport().installEventFilter(self)
 
     def _apply_base_stylesheet(self):
@@ -151,20 +117,20 @@ class SidebarTableWidget(QTableWidget):
         self.viewport().setPalette(palette)
         self.viewport().setAutoFillBackground(True)
         self.setStyleSheet(f"""
-            QTableWidget#sidebar {{ outline: 0; background-color: {base_color}; }}
-            QTableWidget#sidebar::item {{
+            QTreeWidget#sidebar {{ outline: 0; background-color: {base_color}; }}
+            QTreeWidget#sidebar::item {{
                 background: {base_color};
                 color: {text_color};
             }}
-            QTableWidget#sidebar::item:hover {{
+            QTreeWidget#sidebar::item:hover {{
                 background: transparent;
                 color: {text_color};
             }}
-            QTableWidget#sidebar::item:selected {{
+            QTreeWidget#sidebar::item:selected {{
                 background: {highlight_color};
                 color: {highlighted_text_color};
             }}
-            QTableWidget#sidebar::item:focus {{
+            QTreeWidget#sidebar::item:focus {{
                 background: {highlight_color};
                 color: {highlighted_text_color};
             }}
@@ -176,159 +142,132 @@ class SidebarTableWidget(QTableWidget):
             self.viewport().update()
 
     def mousePressEvent(self, event):
+        self._dragging = False
         item = self.itemAt(event.pos())
         if item:
             super().mousePressEvent(event)
         else:
             event.ignore()
 
+    def mouseMoveEvent(self, event):
+        # suppress cursor-following selection while holding the mouse button
+        if event.buttons() & Qt.MouseButton.LeftButton:
+            self._dragging = True
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        if self._dragging:
+            self._dragging = False
+            return  # don't change selection when releasing after a drag
+        super().mouseReleaseEvent(event)
+
     def dragEnterEvent(self, event):
         if event.mimeData().hasUrls():
             event.accept()
-        elif event.source() == self:
-            event.accept()
-            super().dragEnterEvent(event)
         else:
             event.ignore()
 
     def dragMoveEvent(self, event):
         if event.mimeData().hasUrls():
             event.accept()
-        elif event.source() == self:
-            drop_row = self.indexAt(event.pos()).row()
-            if drop_row == -1:
-                drop_row = self.rowCount()
-            if drop_row != self.drop_row:
-                self.drop_row = drop_row
-            event.accept()
-            super().dragMoveEvent(event)
         else:
             event.ignore()
-
-    def dragLeaveEvent(self, event):
-        self.drop_row = -1
-        self.viewport().update()
-        super().dragLeaveEvent(event)
-
-    def paintEvent(self, event):
-        super().paintEvent(event)
-        if self.drop_row >= 0:
-            painter = QPainter(self.viewport())
-            if self.drop_row < self.rowCount():
-                y = self.visualRect(self.model().index(self.drop_row, 0)).top()
-            else:
-                y = self.visualRect(self.model().index(self.rowCount() - 1, 0)).bottom()
-            painter.drawLine(0, y, self.viewport().width(), y)
 
     def dropEvent(self, event):
         if event.mimeData().hasUrls():
             self.parent.event(event)
-        elif event.source() == self:
-            drop_row = self.indexAt(event.pos()).row()
-            if drop_row == -1:
-                drop_row = self.rowCount()
-            selected_rows = sorted(
-                index.row() for index in self.selectionModel().selectedRows()
-            )
-            if selected_rows and drop_row > selected_rows[-1]:
-                drop_row -= len(selected_rows)
-
-            self.drop_row = -1
-            self.viewport().update()
-            self.rowsMoved.emit(selected_rows[0], drop_row)
-            event.setDropAction(Qt.DropAction.IgnoreAction)
-            event.accept()
         else:
             event.ignore()
 
-    def set_dtype(self, row, dtype):
-        """Set the data type badge for the given row."""
-        item = QTableWidgetItem(dtype)
-        item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
-        item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
-        item.setToolTip(f"Data type: {dtype.capitalize()}")
-        self.setItem(row, 2, item)
-
-    def style_rows(self):
-        self.resizeColumnToContents(0)
-        for i in range(self.rowCount()):
-            self.resizeRowToContents(i)
-            self.setRowHeight(i, ROW_HEIGHT)
-            self.item(i, 0).setTextAlignment(
-                Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
-            )
-            self.item(i, 0).setForeground(QColor("gray"))
-            self.item(i, 0).setFlags(
-                self.item(i, 0).flags() & ~Qt.ItemFlag.ItemIsEditable
-            )
-            self.item(i, 1).setTextAlignment(
-                Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
-            )
-            self.item(i, 1).setFlags(
-                self.item(i, 1).flags() | Qt.ItemFlag.ItemIsEditable
-            )
-            if self.item(i, 2) is not None:
-                self.item(i, 2).setFlags(
-                    Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
-                )
-        # after a rebuild (e.g. row removed), the cursor may already be hovering
-        # over a row without a MouseMove firing — update the close button immediately
-        pos = self.viewport().mapFromGlobal(QCursor.pos())
-        index = self.indexAt(pos)
-        self.showCloseButton(index.row() if index.isValid() else -1)
+    def set_dtype(self, item, dtype):
+        """Set the data type badge for the given tree item."""
+        item.setText(1, dtype)
+        item.setToolTip(1, f"Data type: {dtype.capitalize()}" if dtype else "")
 
     def set_badges_visible(self, visible):
         """Show or hide the data type badge column."""
-        self.setColumnHidden(2, not visible)
+        self.setColumnHidden(1, not visible)
 
-    def update_vertical_header(self):
-        row_count = self.rowCount()
-        self.setVerticalHeaderLabels([str(i) for i in range(row_count)])
+    def make_item(self, name, dataset_id):
+        """Create a styled tree item for a dataset."""
+        item = QTreeWidgetItem(["", "", ""])
+        item.setText(0, name)
+        item.setData(0, Qt.ItemDataRole.UserRole, dataset_id)
+        item.setSizeHint(0, QSize(0, ROW_HEIGHT))
+        item.setFlags(
+            Qt.ItemFlag.ItemIsEnabled
+            | Qt.ItemFlag.ItemIsSelectable
+            | Qt.ItemFlag.ItemIsEditable
+        )
+        return item
+
+    def style_items(self):
+        """Update the close button for the item currently under the cursor."""
+        pos = self.viewport().mapFromGlobal(QCursor.pos())
+        hovered = self.itemAt(pos)
+        self.showCloseButton(hovered)
+
+    def _all_items(self):
+        """Yield every tree item in the widget, depth-first."""
+
+        def _recurse(parent_item):
+            for i in range(parent_item.childCount()):
+                child = parent_item.child(i)
+                yield child
+                yield from _recurse(child)
+
+        for i in range(self.topLevelItemCount()):
+            top = self.topLevelItem(i)
+            yield top
+            yield from _recurse(top)
 
     def eventFilter(self, source, event):
         if source == self.viewport() and event.type() == QEvent.Type.MouseMove:
-            index = self.indexAt(event.pos())
-            if index.isValid():
-                self.showCloseButton(index.row())
-            else:
-                self.showCloseButton(-1)
+            item = self.itemAt(event.pos())
+            self.showCloseButton(item)
         elif source == self.viewport() and event.type() == QEvent.Type.Leave:
-            self.showCloseButton(-1)
+            self.showCloseButton(None)
         elif isinstance(source, QToolButton) and event.type() == QEvent.Type.Enter:
-            # guard against the spurious Enter fired by setCellWidget while the button
-            # is still at (0, 0) before the layout pass moves it to column 3
-            for row in range(self.rowCount()):
-                if self.cellWidget(row, 3) is source:
-                    btn_rect = self.visualRect(self.model().index(row, 3))
-                    cursor = self.viewport().mapFromGlobal(QCursor.pos())
-                    if btn_rect.contains(cursor):
-                        source.setStyleSheet("""
-                            QToolButton {
-                                background: rgba(128, 128, 128, 0.2);
-                                border-radius: 4px;
-                            }
-                            QToolButton:pressed {
-                                background: rgba(128, 128, 128, 0.35);
-                                border-radius: 4px;
-                            }
-                        """)
-                    break
+            source.setStyleSheet("""
+                QToolButton {
+                    background: rgba(128, 128, 128, 0.2);
+                    border-radius: 4px;
+                }
+                QToolButton:pressed {
+                    background: rgba(128, 128, 128, 0.35);
+                    border-radius: 4px;
+                }
+            """)
         elif isinstance(source, QToolButton) and event.type() == QEvent.Type.Leave:
-            source.setStyleSheet(
-                "QToolButton { background: transparent; border: none; }"
-            )
-
+            # reset hover style, then transfer button to whichever row the cursor is on
+            source.setStyleSheet("""
+                QToolButton {
+                    background: transparent;
+                    border: none;
+                }
+                QToolButton:pressed {
+                    background: rgba(128, 128, 128, 0.35);
+                    border-radius: 4px;
+                }
+            """)
+            pos = self.viewport().mapFromGlobal(QCursor.pos())
+            self.showCloseButton(self.itemAt(pos))
         return False
 
-    def showCloseButton(self, row_index):
-        for i in range(self.rowCount()):
-            if i == row_index:
-                delete_button = QToolButton()
-                delete_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-                delete_button.setFixedSize(24, ROW_HEIGHT)
-                delete_button.setIcon(QIcon.fromTheme("close-data"))
-                delete_button.setToolTip("Close dataset")
-                delete_button.setStyleSheet("""
+    def showCloseButton(self, hovered_item):
+        """Show the close button on the hovered item; remove it from all others."""
+        for item in self._all_items():
+            if item is hovered_item:
+                if self.itemWidget(item, 2) is not None:
+                    continue  # button already present, don't recreate
+                dataset_id = item.data(0, Qt.ItemDataRole.UserRole)
+                btn = QToolButton()
+                btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+                btn.setFixedSize(24, ROW_HEIGHT)
+                btn.setIcon(QIcon.fromTheme("close-data"))
+                btn.setToolTip("Close dataset")
+                btn.setStyleSheet("""
                     QToolButton {
                         background: transparent;
                         border: none;
@@ -338,9 +277,28 @@ class SidebarTableWidget(QTableWidget):
                         border-radius: 4px;
                     }
                 """)
-                delete_button.clicked.connect(
-                    lambda _, index=row_index: self.parent.model.remove_data(index)
-                )
-                self.setCellWidget(row_index, 3, delete_button)
+                btn.installEventFilter(self)
+                btn.clicked.connect(lambda _, did=dataset_id: self._close_dataset(did))
+                self.setItemWidget(item, 2, btn)
             else:
-                self.removeCellWidget(i, 3)
+                self.removeItemWidget(item, 2)
+
+    def _close_dataset(self, dataset_id):
+        """Close a dataset, cascading to descendants with a confirmation dialog."""
+        descendants = self.parent.model.find_descendants(dataset_id)
+        if descendants:
+            n = len(descendants)
+            msg = QMessageBox(self)
+            msg.setWindowTitle("Close Dataset")
+            msg.setIcon(QMessageBox.Icon.Warning)
+            msg.setText(
+                f"Closing this dataset will also close {n} child "
+                f"dataset{'s' if n != 1 else ''}."
+            )
+            msg.setStandardButtons(
+                QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel
+            )
+            msg.setDefaultButton(QMessageBox.StandardButton.Cancel)
+            if msg.exec() != QMessageBox.StandardButton.Ok:
+                return
+        self.parent.model.remove_data_cascade(dataset_id)


### PR DESCRIPTION
Since datasets always have a parent (unless they were loaded from a file), it makes sense to display them as a tree in the sidebar.

For now, this means that datasets cannot be reordered (this was previously possible via drag and drop). Also, there are no dataset numbers anymore.

Closing a dataset will also close all its children (but show a warning dialog if that's the case).