### PR TITLE
Fix support for embedded montages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### ✨ Added
 - Add a "Toolbar" page to the Settings dialog that allows users to customize the toolbar ([#654](https://github.com/cbrnr/mnelab/pull/654) by [Clemens Brunner](https://github.com/cbrnr))
 
+### 🔧 Fixed
+- Properly import channel locations from EEGLAB files ([#655](https://github.com/cbrnr/mnelab/pull/655) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [1.5.1] · 2026-05-21
 ### 🔧 Fixed
 - Fix a bug where a dataset could not be closed in the sidebar ([#653](https://github.com/cbrnr/mnelab/pull/653) by [Clemens Brunner](https://github.com/cbrnr))

--- a/src/mnelab/dialogs/montage.py
+++ b/src/mnelab/dialogs/montage.py
@@ -41,11 +41,12 @@ SUPPORTED_FILES = [
 
 
 class MontageItem(QListWidgetItem):
-    def __init__(self, montage, name, path=None):
+    def __init__(self, montage, name, path=None, embedded=False):
         super().__init__(name)
         self.montage = montage
         self.name = name
         self.path = path
+        self.embedded = embedded
 
 
 class MontageDialog(QDialog):
@@ -109,13 +110,14 @@ class MontageDialog(QDialog):
         self.setLayout(main_layout)
 
         if current_montage is not None:
-            if current_montage.path is not None:
-                # custom montage: add it to the list and select it
+            if current_montage.path is not None or current_montage.embedded:
+                # custom or embedded montage: add it to the list and select it
                 self.montages.addItem(
                     MontageItem(
                         current_montage.montage,
                         current_montage.name,
                         current_montage.path,
+                        current_montage.embedded,
                     )
                 )
                 self.montages.setCurrentRow(self.montages.count() - 1)
@@ -133,7 +135,7 @@ class MontageDialog(QDialog):
         if selected:
             item = selected[0]
             assert isinstance(item, MontageItem)
-            self.montage = Montage(item.montage, item.name, item.path)
+            self.montage = Montage(item.montage, item.name, item.path, item.embedded)
         else:
             self.montage = None
         super().accept()

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -672,7 +672,7 @@ class MainWindow(QMainWindow):
             self.all_actions["plot_locations"].setEnabled(enabled and locations)
             ica = bool(self.model.current["ica"])
             self.all_actions["label_ica"].setEnabled(
-                enabled and ica and self.model.current["montage"] is not None
+                enabled and ica and bool(locations)
             )
             self.all_actions["apply_ica"].setEnabled(enabled and ica)
             self.all_actions["export_ica"].setEnabled(enabled and ica)
@@ -1071,11 +1071,13 @@ class MainWindow(QMainWindow):
         if dialog.exec():
             montage = dialog.montage
             if montage is None:
+                self.auto_duplicate()
                 self.model.set_montage(None)
                 return
             ch_names = self.model.current["data"].info["ch_names"]
             # check if at least one channel name matches a name in the montage
             if set(ch_names) & set(montage.montage.ch_names):
+                self.auto_duplicate()
                 self.model.set_montage(
                     montage,
                     match_case=dialog.match_case.isChecked(),

--- a/src/mnelab/model.py
+++ b/src/mnelab/model.py
@@ -216,7 +216,11 @@ class Model:
             events = np.empty((0, 3), dtype=int)
             event_mapping = defaultdict(str)
         dig_montage = data.get_montage()
-        montage = Montage(dig_montage, "Custom", embedded=True) if dig_montage is not None else None
+        montage = (
+            Montage(dig_montage, "Custom", embedded=True)
+            if dig_montage is not None
+            else None
+        )
         self.insert_data(
             defaultdict(
                 lambda: None,

--- a/src/mnelab/model.py
+++ b/src/mnelab/model.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from mnelab.io import UnsupportedFileTypeError, read_epochs, read_raw, write_raw
 from mnelab.io.readers import split_name_ext
-from mnelab.utils import count_locations, run_iclabel
+from mnelab.utils import Montage, count_locations, run_iclabel
 
 
 class LabelsNotFoundError(Exception):
@@ -215,6 +215,8 @@ class Model:
             dtype = "raw"
             events = np.empty((0, 3), dtype=int)
             event_mapping = defaultdict(str)
+        dig_montage = data.get_montage()
+        montage = Montage(dig_montage, "Custom", embedded=True) if dig_montage is not None else None
         self.insert_data(
             defaultdict(
                 lambda: None,
@@ -224,7 +226,7 @@ class Model:
                 fsize=fsize,
                 data=data,
                 dtype=dtype,
-                montage=None,
+                montage=montage,
                 events=events,
                 event_mapping=event_mapping,
                 _cache_path=None,
@@ -672,7 +674,7 @@ class Model:
         )
         if montage is None:
             self.history.append("data.set_montage(None)")
-        else:
+        elif not montage.embedded:
             if montage.path is not None:
                 self.history.append(
                     f"montage = mne.read_custom_montage('{montage.path}')"

--- a/src/mnelab/utils/utils.py
+++ b/src/mnelab/utils/utils.py
@@ -331,3 +331,4 @@ class Montage:
     montage: DigMontage
     name: str
     path: Path | None = None
+    embedded: bool = False


### PR DESCRIPTION
Previously, files containing electrode locations could be imported, and the locations also showed up in the info widget, but it was not properly handled as a montage. This means that no preview was available in the "Set Montage" dialog, and "Label ICs" was also disabled because it required a proper montage.