### PR TITLE
Always show toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### 🔧 Fixed
 - Properly import channel locations from EEGLAB files ([#655](https://github.com/cbrnr/mnelab/pull/655) by [Clemens Brunner](https://github.com/cbrnr))
 
+### 🌀 Changed
+- Always show the toolbar ([#659](https://github.com/cbrnr/mnelab/pull/659) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [1.5.1] · 2026-05-21
 ### 🔧 Fixed
 - Fix a bug where a dataset could not be closed in the sidebar ([#653](https://github.com/cbrnr/mnelab/pull/653) by [Clemens Brunner](https://github.com/cbrnr))

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -413,17 +413,13 @@ class MainWindow(QMainWindow):
             self.show_history,
             QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_Y),
         )
-        self.all_actions["toolbar"] = view_menu.addAction(
-            "&Toolbar", self._toggle_toolbar
-        )
-        self.all_actions["toolbar"].setCheckable(True)
         self.all_actions["statusbar"] = view_menu.addAction(
-            "&Statusbar", self._toggle_statusbar
+            "&Status Bar", self._toggle_statusbar
         )
         self.all_actions["statusbar"].setCheckable(True)
         if sys.platform != "darwin":
             self.all_actions["menubar"] = view_menu.addAction(
-                "&Menubar",
+                "&Menu Bar",
                 self._toggle_menubar,
                 QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_M),
             )
@@ -461,7 +457,6 @@ class MainWindow(QMainWindow):
             "check_updates",
             "quit",
             "xdf_chunks",
-            "toolbar",
             "statusbar",
             "menubar",
             "settings",
@@ -514,12 +509,7 @@ class MainWindow(QMainWindow):
                     border-radius: 4px;
                 }
             """)
-        if settings["toolbar"]:
-            self.toolbar.show()
-            self.all_actions["toolbar"].setChecked(True)
-        else:
-            self.toolbar.hide()
-            self.all_actions["toolbar"].setChecked(False)
+        self.toolbar.show()
 
         # set up data model for sidebar (list of open files)
         self.sidebar_container = SidebarWidget(self)
@@ -1910,14 +1900,6 @@ class MainWindow(QMainWindow):
     @Slot(QAction)
     def _load_recent(self, action):
         self.open_data(fname=action.text())
-
-    @Slot()
-    def _toggle_toolbar(self):
-        if self.toolbar.isHidden():
-            self.toolbar.show()
-        else:
-            self.toolbar.hide()
-        write_settings(toolbar=not self.toolbar.isHidden())
 
     def _apply_toolbar(self, action_keys):
         for action in list(self.toolbar.actions()):

--- a/src/mnelab/settings.py
+++ b/src/mnelab/settings.py
@@ -52,7 +52,6 @@ _DEFAULTS = {
     "duration": 20,
     "epochs": 10,
     "recent": [],
-    "toolbar": True,
     "statusbar": True,
     "size": QSize(700, 500),
     "pos": QPoint(100, 100),
@@ -411,7 +410,7 @@ class SettingsDialog(QDialog):
         clear_settings()
 
     def _populate_toolbar_page(self, current_keys):
-        excluded = {"toolbar", "statusbar", "menubar"}
+        excluded = {"statusbar", "menubar"}
         all_actions = self.parent().all_actions
         in_toolbar = {k for k in current_keys if k != "---"}
         for key in current_keys:


### PR DESCRIPTION
It doesn't make sense for users to hide the toolbar, especially when they also disable the menu bar (which means that the menu is shown in the toolbar, so we have to show the toolbar).