### PR TITLE
Fix drag and drop onto sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] · YYYY-MM-DD
+### 🔧 Fixed
+- Fix bug where files could not be opened via drag and drop onto the sidebar ([#666](https://github.com/cbrnr/mnelab/pull/666) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.5.3] · 2026-05-29
 ### ✨ Added

--- a/src/mnelab/widgets/sidebar.py
+++ b/src/mnelab/widgets/sidebar.py
@@ -181,7 +181,7 @@ class SidebarTreeWidget(QTreeWidget):
 
     def dropEvent(self, event):
         if event.mimeData().hasUrls():
-            self.parent.event(event)
+            self.window().event(event)
         else:
             event.ignore()
 


### PR DESCRIPTION
This PR fixes an issue where a file could not be dropped onto the sidebar to open (but it worked in all other window regions).