### PR TITLE
Fix single-window IC plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### 🔧 Fixed
 - Fix bug where files could not be opened via drag and drop onto the sidebar ([#666](https://github.com/cbrnr/mnelab/pull/666) by [Clemens Brunner](https://github.com/cbrnr))
 - Fix crash when plotting ICA components that were computed before a montage was set ([#667](https://github.com/cbrnr/mnelab/issues/667) by [Clemens Brunner](https://github.com/cbrnr))
+- Fix a bug where plotting less than 21 ICA components would show an error message ([#668](https://github.com/cbrnr/mnelab/issues/668) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.5.3] · 2026-05-29
 ### ✨ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### 🔧 Fixed
 - Fix bug where files could not be opened via drag and drop onto the sidebar ([#666](https://github.com/cbrnr/mnelab/pull/666) by [Clemens Brunner](https://github.com/cbrnr))
 - Fix crash when plotting ICA components that were computed before a montage was set ([#667](https://github.com/cbrnr/mnelab/issues/667) by [Clemens Brunner](https://github.com/cbrnr))
-- Fix a bug where plotting less than 21 ICA components would show an error message ([#668](https://github.com/cbrnr/mnelab/issues/668) by [Clemens Brunner](https://github.com/cbrnr))
+- Fix a bug where plotting fewer than 21 ICA components would display an error message ([#668](https://github.com/cbrnr/mnelab/issues/668) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.5.3] · 2026-05-29
 ### ✨ Added

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -1261,6 +1261,8 @@ class MainWindow(QMainWindow):
         figs = self.model.current["ica"].plot_components(
             inst=self.model.current["data"]
         )
+        if not isinstance(figs, list):
+            figs = [figs]
         # refresh UI after closing the plots to reflect changes in ICA exclusions
         for fig in figs:
             fig.canvas.mpl_connect("close_event", lambda _: self.data_changed())


### PR DESCRIPTION
When plotting fewer than 21 ICs, only a single window is created, but MNELAB assumed it would always be a list (as is the case for 21 or more ICs, which are plotted in multiple windows). This PR fixes this issue.