### PR TITLE
Support string streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [UNRELEASED] · YYYY-MM-DD
 
 ### 🔧 Fixed
-- Add support for XDF string streams with more than one channel and/or regular sampling rates ([#???](https://github.com/cbrnr/mnelab/issues/???) by [Clemens Brunner](https://github.com/cbrnr))
+- Add support for XDF string streams with more than one channel and/or regular sampling rates ([#671](https://github.com/cbrnr/mnelab/issues/671) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.5.4] · 2026-06-16
 ### 🔧 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [UNRELEASED] · YYYY-MM-DD
 
+### 🔧 Fixed
+- Add support for XDF string streams with more than one channel and/or regular sampling rates ([#???](https://github.com/cbrnr/mnelab/issues/???) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [1.5.4] · 2026-06-16
 ### 🔧 Fixed
 - Fix bug where files could not be opened via drag and drop onto the sidebar ([#666](https://github.com/cbrnr/mnelab/pull/666) by [Clemens Brunner](https://github.com/cbrnr))

--- a/src/mnelab/dialogs/xdf_streams.py
+++ b/src/mnelab/dialogs/xdf_streams.py
@@ -194,7 +194,7 @@ class XDFStreamsDialog(QDialog):
             type_ = self.view.item(row.row(), 2).text()
             fmt = self.view.item(row.row(), 4).text()
             fs = self.view.item(row.row(), 5).value()
-            if type_ != "Markers" and fs != 0 and fmt != "string":
+            if type_ not in {"Marker", "Markers"} and fs != 0 and fmt != "string":
                 streams.append(self.view.item(row.row(), 0).value())
         return streams
 
@@ -204,6 +204,6 @@ class XDFStreamsDialog(QDialog):
         for row in self.view.selectionModel().selectedRows():
             type_ = self.view.item(row.row(), 2).text()
             fs = self.view.item(row.row(), 5).value()
-            if type_ == "Markers" and fs == 0:
+            if type_ in {"Marker", "Markers"} and fs == 0:
                 markers.append(self.view.item(row.row(), 0).value())
         return markers

--- a/src/mnelab/dialogs/xdf_streams.py
+++ b/src/mnelab/dialogs/xdf_streams.py
@@ -192,8 +192,9 @@ class XDFStreamsDialog(QDialog):
         streams = []
         for row in self.view.selectionModel().selectedRows():
             type_ = self.view.item(row.row(), 2).text()
+            fmt = self.view.item(row.row(), 4).text()
             fs = self.view.item(row.row(), 5).value()
-            if type_ != "Markers" and fs != 0:
+            if type_ != "Markers" and fs != 0 and fmt != "string":
                 streams.append(self.view.item(row.row(), 0).value())
         return streams
 

--- a/src/mnelab/io/xdf.py
+++ b/src/mnelab/io/xdf.py
@@ -83,7 +83,7 @@ class RawXDF(BaseRaw):
         streams, header = load_xdf(fname)
         streams = {stream["info"]["stream_id"]: stream for stream in streams}
 
-        if all(_is_markerstream(streams[stream_id]) for stream_id in stream_ids):
+        if all(_is_stringstream(streams[stream_id]) for stream_id in stream_ids):
             raise RuntimeError(
                 "Loading only marker streams is not supported, at least one stream must"
                 " be a regular stream."
@@ -152,18 +152,26 @@ class RawXDF(BaseRaw):
         data = (data * scale).T
         super().__init__(preload=data, info=info, filenames=[fname], *args, **kwargs)
 
-        # convert marker streams to annotations
+        # convert string streams to annotations
         for stream_id, stream in streams.items():
-            if marker_ids is not None and stream_id not in marker_ids:
+            if not _is_stringstream(stream):
                 continue
-            if not _is_markerstream(stream):
+            srate = float(stream["info"]["nominal_srate"][0])
+            # classic marker streams (srate=0) respect the user's marker selection;
+            # regular-rate string streams are always converted automatically
+            if srate == 0 and marker_ids is not None and stream_id not in marker_ids:
                 continue
-            onsets = stream["time_stamps"] - first_time
             prefix = f"{stream_id}-" if prefix_markers else ""
-            descriptions = [
-                f"{prefix}{item}" for sub in stream["time_series"] for item in sub
-            ]
-            self.annotations.append(onsets, [0] * len(onsets), descriptions)
+            onsets_list, descriptions_list = [], []
+            for ts, sub in zip(stream["time_stamps"], stream["time_series"]):
+                for item in sub:
+                    if item:  # skip empty strings
+                        onsets_list.append(ts - first_time)
+                        descriptions_list.append(f"{prefix}{item}")
+            if onsets_list:
+                self.annotations.append(
+                    onsets_list, [0] * len(onsets_list), descriptions_list
+                )
 
         recording_datetime = header["info"].get("datetime", [None])[0]
         if recording_datetime is not None:
@@ -354,10 +362,8 @@ def read_raw_xdf(
     )
 
 
-def _is_markerstream(stream):
-    srate = float(stream["info"]["nominal_srate"][0])
-    n_chans = int(stream["info"]["channel_count"][0])
-    return srate == 0 and n_chans == 1
+def _is_stringstream(stream):
+    return stream["info"]["channel_format"][0] == "string"
 
 
 def get_xml(fname):

--- a/src/mnelab/io/xdf.py
+++ b/src/mnelab/io/xdf.py
@@ -144,6 +144,8 @@ class RawXDF(BaseRaw):
             fs = float(
                 np.array(streams[stream_ids[0]]["info"]["effective_srate"]).item()
             )
+            if fs == 0:  # fall back to nominal rate (e.g. when only one sample exists)
+                fs = float(streams[stream_ids[0]]["info"]["nominal_srate"][0])
 
         info = mne.create_info(ch_names=labels_all, sfreq=fs, ch_types=types_all)
 

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -771,6 +771,7 @@ class MainWindow(QMainWindow):
                         s["nominal_srate"],
                     ]
                     for s in resolve_streams(fname)
+                    if s["channel_format"] != "string"
                 ]
                 dialog = XDFStreamsDialog(
                     self,


### PR DESCRIPTION
Add support for string streams (which are always interpreted as marker streams corresponding to annotations in MNE), including multi-channel and regular sampling rates (fs > 0).