### PR TITLE
Hide .GZ in file type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### 🔧 Fixed
 - Add support for XDF string streams with more than one channel and/or regular sampling rates ([#671](https://github.com/cbrnr/mnelab/issues/671) by [Clemens Brunner](https://github.com/cbrnr))
 
+### 🌀 Changed
+- Do not show .GZ for XDF.GZ and FIF.GZ file types in the info widget (just show XDF and FIF) ([#672](https://github.com/cbrnr/mnelab/issues/672) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [1.5.4] · 2026-06-16
 ### 🔧 Fixed
 - Fix bug where files could not be opened via drag and drop onto the sidebar ([#666](https://github.com/cbrnr/mnelab/pull/666) by [Clemens Brunner](https://github.com/cbrnr))

--- a/src/mnelab/model.py
+++ b/src/mnelab/model.py
@@ -619,7 +619,7 @@ class Model:
             annots = "–"
         return {
             "File Name": fname if fname else "–",
-            "File Type": ftype if ftype else "–",
+            "File Type": ftype.removesuffix(".GZ") if ftype else "–",
             "Data Type": dtype,
             "Size on Disk": size_disk,
             "Size in Memory": f"{data.get_data().nbytes / 1024**2:.2f}\u2009MB",


### PR DESCRIPTION
Show XDF or FIF instead of XDF.GZ or FIF.GZ in the info widget.