### PR TITLE
Add "auto"/"fixed" options for channel scalings in plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] · YYYY-MM-DD
+### ✨ Added
+- Add a "Channel Scaling" option to the plotting settings page to choose between auto-scaling (based on the 99.5th percentile of the data) and fixed scaling (MNE defaults per channel type) ([#675](https://github.com/cbrnr/mnelab/issues/675) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### 🔧 Fixed
 - Add support for XDF string streams with more than one channel and/or regular sampling rates ([#671](https://github.com/cbrnr/mnelab/issues/671) by [Clemens Brunner](https://github.com/cbrnr))

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -1206,7 +1206,12 @@ class MainWindow(QMainWindow):
         if events is not None and len(events):
             hist_parts.append("events=events")
 
-        fig = self.model.current["data"].plot(**kwargs)
+        scalings = read_settings("scalings")
+        if scalings == "auto":
+            hist_parts.append('scalings="auto"')
+        fig = self.model.current["data"].plot(
+            scalings="auto" if scalings == "auto" else None, **kwargs
+        )
         self.model.history.append(f"data.plot({', '.join(hist_parts)})")
         if mne.viz.get_browser_backend() == "matplotlib":
             win = fig.canvas.manager.window

--- a/src/mnelab/settings.py
+++ b/src/mnelab/settings.py
@@ -63,6 +63,7 @@ _DEFAULTS = {
     "show_menubar": True,
     "annotation_colors": {},
     "memory_saving": False,
+    "scalings": "auto",
     "toolbar_actions": [
         "open_file",
         "---",
@@ -240,6 +241,11 @@ class SettingsDialog(QDialog):
         self.epochs.setFixedWidth(100)
         plotting_form.addRow("Displayed Epochs:", self.epochs)
 
+        self.scalings = QComboBox()
+        self.scalings.addItems(["Auto", "Fixed"])
+        self.scalings.setCurrentText(read_settings("scalings").title())
+        plotting_form.addRow("Channel Scaling:", self.scalings)
+
         self._stack.addWidget(plotting_page)
 
         # Toolbar page
@@ -385,6 +391,7 @@ class SettingsDialog(QDialog):
             dtype_badges=self.dtype_badges.isChecked(),
             menu_icons=self.menu_icons.isChecked(),
             memory_saving=self.memory_saving.isChecked(),
+            scalings=self.scalings.currentText().lower(),
             toolbar_actions=toolbar_keys,
         )
         self.parent().recent = self.parent().recent[: read_settings("max_recent")]
@@ -403,6 +410,7 @@ class SettingsDialog(QDialog):
         self.plot_backend.setCurrentIndex(
             self.plot_backend.findText(_DEFAULTS["plot_backend"])
         )
+        self.scalings.setCurrentText(_DEFAULTS["scalings"].title())
         self.parent().resize(_DEFAULTS["size"])
         self.parent().move(_DEFAULTS["pos"])
         self.parent().recent = []


### PR DESCRIPTION
Previously, the default `scalings=None`, corresponding to a fixed (hard-coded) scaling per channel type was used. Now the new default is `scalings="auto"`, which uses the actual data min/max. Users can set their preferred scaling in the Settings dialog ("auto"/"fixed").

<img width="782" height="520" alt="Screenshot 2026-06-25 at 17 02 57" src="https://github.com/user-attachments/assets/7ab76682-8db9-4275-ac3e-c521c20506db" />