### PR TITLE
Automatize release process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+# CLAUDE.md
 
 Guidelines for AI coding agents working on this repository.
 
@@ -55,17 +55,12 @@ Every PR must include an entry in the `[UNRELEASED]` section of [CHANGELOG.md](C
 
 ## Release
 
-1. Remove the `.dev0` suffix from the `version` field in `pyproject.toml` (and/or adapt the version to be released if necessary).
-2. Run `uv lock` to update `uv.lock` with the new version.
-3. Update the section in `CHANGELOG.md` corresponding to the new release with the version and current date.
-4. Update the section on the standalone installers in `README.md` and `docs/tutorial/index.md` (use the to-be-released version in the URLs, e.g., https://github.com/cbrnr/mnelab/releases/download/v1.0.3/MNELAB-1.0.3.exe).
-5. Commit these changes and push.
-6. Create a new release on GitHub and use the version as the tag name (make sure to prepend the version with a `v`, e.g. `v0.7.0`).
-7. A GitHub Action takes care of building and uploading wheels to PyPI as well as adding standalone installers to the release.
+1. Run `uv run tools/release.py prepare X.Y.Z` (with the version to be released). This removes the `.dev0` suffix from the `version` field in `pyproject.toml`, dates the `## [UNRELEASED]` heading in `CHANGELOG.md` with the version and today's date, updates the standalone installer URLs in `README.md` and `docs/quickstart/index.md`, and runs `uv lock`.
+2. Review the resulting changes, then commit and push them.
+3. Create a new release on GitHub and use the version as the tag name (make sure to prepend the version with a `v`, e.g. `v0.7.0`). Use `uv run tools/release.py notes X.Y.Z` to print the CHANGELOG entries for the release notes.
+4. A GitHub Action takes care of building and uploading wheels to PyPI as well as adding standalone installers to the release.
 
 This concludes the new release. Now prepare the source for the next planned release as follows:
 
-1. Update the `version` field to the next planned release and append `.dev0`.
-2. Run `uv lock` to update `uv.lock` with the new version.
-3. Start a new section at the top of `CHANGELOG.md` titled `## [UNRELEASED] · YYYY-MM-DD`.
-4. Commit ("Prepare next dev version") and push.
+1. Run `uv run tools/release.py bump X.Y.Z` (with the next planned version). This sets the `version` field to `X.Y.Z.dev0`, starts a fresh `## [UNRELEASED] · YYYY-MM-DD` section at the top of `CHANGELOG.md`, and runs `uv lock`.
+2. Commit ("Prepare next dev version") and push.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,19 +80,15 @@ MNELAB uses [Ruff](https://docs.astral.sh/ruff/formatter/) for formatting. Becau
 
 Follow these steps to make a new [PyPI](https://pypi.org/project/mnelab/) release (requires write permissions for GitHub and PyPI project sites):
 
-1. Remove the `.dev0` suffix from the `version` field in `pyproject.toml` (and/or adapt the version to be released if necessary)
-2. Run `uv lock` to update `uv.lock` with the new version
-3. Update the section in `CHANGELOG.md` corresponding to the new release with the version and current date
-4. Update the section on the standalone installers in `README.md` and `docs/quickstart/index.md` (use the to-be-released version in the URLs, e.g., https://github.com/cbrnr/mnelab/releases/download/v1.0.3/MNELAB-1.0.3.exe)
-5. Commit these changes and push
-6. Create a new release on GitHub and use the version as the tag name (make sure to prepend the version with a `v`, e.g. `v0.7.0`)
-7. A GitHub Action takes care of building and uploading wheels to PyPI as well as adding standalone installers to the release
+1. Run `uv run tools/release.py prepare X.Y.Z` (with the version to be released). This removes the `.dev0` suffix from the `version` field in `pyproject.toml`, dates the `## [UNRELEASED]` heading in `CHANGELOG.md` with the version and today's date, updates the standalone installer URLs in `README.md` and `docs/quickstart/index.md`, and runs `uv lock`
+2. Review the resulting changes, then commit and push them
+3. Create a new release on GitHub and use the version as the tag name (make sure to prepend the version with a `v`, e.g. `v0.7.0`); use `uv run tools/release.py notes X.Y.Z` to print the CHANGELOG entries for the release notes
+4. A GitHub Action takes care of building and uploading wheels to PyPI as well as adding standalone installers to the release
 
 This concludes the new release. Now prepare the source for the next planned release as follows:
 
-1. Update the `version` field to the next planned release and append `.dev0`
-2. Run `uv lock` to update `uv.lock` with the new version
-3. Start a new section at the top of `CHANGELOG.md` titled `## [UNRELEASED] · YYYY-MM-DD`
+1. Run `uv run tools/release.py bump X.Y.Z` (with the next planned version). This sets the `version` field to `X.Y.Z.dev0`, starts a fresh `## [UNRELEASED] · YYYY-MM-DD` section at the top of `CHANGELOG.md`, and runs `uv lock`
+2. Commit ("Prepare next dev version") and push
 
 Don't forget to commit and push these changes!
 

--- a/tools/release.py
+++ b/tools/release.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+"""Automate MNELAB release process.
+
+Run from the repository root:
+
+  # turn the current dev checkout into a release checkout (and update the lock)
+  uv run tools/release.py prepare 1.6.0
+
+  # after the release: bump to the next dev version and reopen the CHANGELOG
+  uv run tools/release.py bump 1.7.0
+
+  # print the CHANGELOG entries for a version (handy as GitHub release notes)
+  uv run tools/release.py notes 1.6.0
+
+`prepare` and `bump` run `uv lock` at the end. Both leave the resulting changes
+uncommitted so they can be reviewed before commit.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+CHANGELOG = ROOT / "CHANGELOG.md"
+# files that reference the released version in the installer download URLs
+URL_FILES = [ROOT / "README.md", ROOT / "docs" / "quickstart" / "index.md"]
+
+VERSION_RE = re.compile(r"^version = \"[^\"]*\"$", re.MULTILINE)
+
+
+def set_version(version):
+    """Set the `version` field in pyproject.toml."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    text, n = VERSION_RE.subn(f'version = "{version}"', text, count=1)
+    if n != 1:
+        sys.exit("Could not find a unique version field in pyproject.toml.")
+    PYPROJECT.write_text(text, encoding="utf-8")
+
+
+def update_urls(version):
+    """Point the installer download links to `version`."""
+    for path in URL_FILES:
+        text = path.read_text(encoding="utf-8")
+        # e.g. releases/download/v1.6.0/MNELAB-1.6.0.dmg
+        text = re.sub(
+            r"releases/download/v\d+\.\d+\.\d+/MNELAB-\d+\.\d+\.\d+\.(dmg|exe)",
+            rf"releases/download/v{version}/MNELAB-{version}.\1",
+            text,
+        )
+        # e.g. link text "MNELAB 1.6.0 (macOS)"
+        text = re.sub(
+            r"MNELAB \d+\.\d+\.\d+ \((macOS|Windows)\)",
+            rf"MNELAB {version} (\1)",
+            text,
+        )
+        path.write_text(text, encoding="utf-8")
+
+
+def uv_lock():
+    """Update uv.lock to reflect the new version."""
+    subprocess.run(["uv", "lock"], cwd=ROOT, check=True)
+
+
+def prepare(version):
+    """Turn the current dev checkout into a release checkout for `version`."""
+    set_version(version)
+    update_urls(version)
+    text = CHANGELOG.read_text(encoding="utf-8")
+    text, n = re.subn(
+        r"^## \[UNRELEASED\].*$",
+        f"## [{version}] · {date.today().isoformat()}",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if n != 1:
+        sys.exit("Could not find an [UNRELEASED] heading in CHANGELOG.md.")
+    CHANGELOG.write_text(text, encoding="utf-8")
+    uv_lock()
+
+
+def bump(next_version):
+    """Set the version to `next_version.dev0` and open a fresh CHANGELOG section."""
+    set_version(f"{next_version}.dev0")
+    text = CHANGELOG.read_text(encoding="utf-8")
+    if not text.startswith("## ["):
+        sys.exit("CHANGELOG.md does not start with a version heading.")
+    CHANGELOG.write_text("## [UNRELEASED] · YYYY-MM-DD\n\n" + text, encoding="utf-8")
+    uv_lock()
+
+
+def notes(version):
+    """Print the CHANGELOG entries for `version` (without the heading)."""
+    text = CHANGELOG.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        sys.exit(f"Could not find a CHANGELOG section for version {version}.")
+    print(match.group(1).strip())
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("prepare", help="prepare the release version")
+    p.add_argument("version")
+
+    p = sub.add_parser("bump", help="bump to the next development version")
+    p.add_argument("version")
+
+    p = sub.add_parser("notes", help="print release notes for a version")
+    p.add_argument("version")
+
+    args = parser.parse_args()
+    if args.command == "prepare":
+        prepare(args.version)
+    elif args.command == "bump":
+        bump(args.version)
+    elif args.command == "notes":
+        notes(args.version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Instead of running several manual steps, there is now a single tool that prepares the release and bumps after the release.