### PR TITLE
Fix XDF marker streams not shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## [UNRELEASED] · YYYY-MM-DD
+### 🔧 Fixed
+- Fix a regression where marker streams were not shown in the selection dialog and never converted to annotations when loading XDF files ([#678](https://github.com/cbrnr/mnelab/pull/678) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.5.5] · 2026-07-02
 ### ✨ Added
 - Add a "Channel Scaling" option to the plotting settings page to choose between auto-scaling (based on the 99.5th percentile of the data) and fixed scaling (MNE defaults per channel type) ([#675](https://github.com/cbrnr/mnelab/issues/675) by [Clemens Brunner](https://github.com/cbrnr))
-
-### 🔧 Fixed
 - Add support for XDF string streams with more than one channel and/or regular sampling rates ([#671](https://github.com/cbrnr/mnelab/issues/671) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### 🌀 Changed

--- a/src/mnelab/dialogs/xdf_streams.py
+++ b/src/mnelab/dialogs/xdf_streams.py
@@ -5,6 +5,7 @@
 from collections import defaultdict
 
 from PySide6.QtCore import Qt, Slot
+from PySide6.QtGui import QPalette
 from PySide6.QtWidgets import (
     QCheckBox,
     QDialog,
@@ -26,11 +27,14 @@ from mnelab.widgets import FlatDoubleSpinBox
 
 
 class XDFStreamsDialog(QDialog):
-    def __init__(self, parent, rows, fname, selected=None):
+    def __init__(self, parent, rows, fname):
         super().__init__(parent)
         self.setWindowTitle("Select XDF Stream")
         self.fname = fname
 
+        muted = self.palette().color(
+            QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text
+        )
         self.view = QTableWidget(len(rows), 6)
         for i, row in enumerate(rows):
             self.view.setItem(i, 0, IntTableWidgetItem(row[0]))
@@ -39,6 +43,13 @@ class XDFStreamsDialog(QDialog):
             self.view.setItem(i, 3, IntTableWidgetItem(row[3]))
             self.view.setItem(i, 4, QTableWidgetItem(row[4]))
             self.view.setItem(i, 5, FloatTableWidgetItem(row[5]))
+            if row[4] == "string":  # marker stream
+                font = self.view.item(i, 0).font()
+                font.setItalic(True)
+                for col in range(self.view.columnCount()):
+                    item = self.view.item(i, col)
+                    item.setForeground(muted)
+                    item.setFont(font)
 
         self.view.setHorizontalHeaderLabels(
             [
@@ -57,10 +68,9 @@ class XDFStreamsDialog(QDialog):
         self.view.verticalHeader().setVisible(False)
         self.view.horizontalHeader().setStretchLastSection(True)
         self.view.setShowGrid(False)
-        if selected is not None:
-            self.view.selectRow(selected)
         self.view.setSortingEnabled(True)
         self.view.sortByColumn(0, Qt.SortOrder.AscendingOrder)
+        self.view.selectAll()
 
         self.view.itemSelectionChanged.connect(self.toggle_buttons)
 
@@ -89,6 +99,12 @@ class XDFStreamsDialog(QDialog):
         self._prefix_markers = QCheckBox("Prefix Markers with Stream ID")
         self._prefix_markers.setChecked(False)
 
+        self.marker_note = QLabel(
+            "Selected marker streams are automatically converted to annotations."
+        )
+        self.marker_note.setWordWrap(True)
+        self.marker_note.setStyleSheet(f"color: {muted.name()}; font-style: italic;")
+
         hbox1 = QHBoxLayout()
         hbox1.addWidget(self.resample)
         hbox1.addWidget(self.resample_label)
@@ -102,6 +118,7 @@ class XDFStreamsDialog(QDialog):
 
         vbox = QVBoxLayout(self)
         vbox.addWidget(self.view)
+        vbox.addWidget(self.marker_note)
         vbox.addLayout(hbox1)
 
         hbox2 = QHBoxLayout()
@@ -174,7 +191,11 @@ class XDFStreamsDialog(QDialog):
             # suggest the most common sampling rate (with the most channels)
             channel_counts = []
             sampling_rates = []
-            row_indices = {r.row() for r in self.view.selectedIndexes()}
+            row_indices = {
+                r.row()
+                for r in self.view.selectedIndexes()
+                if not self._is_marker_row(r.row())
+            }
             for row in row_indices:
                 channel_counts.append(self.view.item(row, 3).value())
                 sampling_rates.append(self.view.item(row, 5).value())
@@ -187,23 +208,22 @@ class XDFStreamsDialog(QDialog):
             suggested_fs = max(counts, key=counts.get)
             self.fs_new.setValue(suggested_fs)
 
+    def _is_marker_row(self, row):
+        """Return whether `row` is a marker (string-format) stream."""
+        return self.view.item(row, 4).text() == "string"
+
     @property
     def selected_streams(self):
-        streams = []
-        for row in self.view.selectionModel().selectedRows():
-            type_ = self.view.item(row.row(), 2).text()
-            fmt = self.view.item(row.row(), 4).text()
-            fs = self.view.item(row.row(), 5).value()
-            if type_ not in {"Marker", "Markers"} and fs != 0 and fmt != "string":
-                streams.append(self.view.item(row.row(), 0).value())
-        return streams
+        return [
+            self.view.item(row.row(), 0).value()
+            for row in self.view.selectionModel().selectedRows()
+            if not self._is_marker_row(row.row())
+        ]
 
     @property
     def selected_markers(self):
-        markers = []
-        for row in self.view.selectionModel().selectedRows():
-            type_ = self.view.item(row.row(), 2).text()
-            fs = self.view.item(row.row(), 5).value()
-            if type_ in {"Marker", "Markers"} and fs == 0:
-                markers.append(self.view.item(row.row(), 0).value())
-        return markers
+        return [
+            self.view.item(row.row(), 0).value()
+            for row in self.view.selectionModel().selectedRows()
+            if self._is_marker_row(row.row())
+        ]

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -769,14 +769,8 @@ class MainWindow(QMainWindow):
                         s["nominal_srate"],
                     ]
                     for s in resolve_streams(fname)
-                    if s["channel_format"] != "string"
                 ]
-                dialog = XDFStreamsDialog(
-                    self,
-                    rows,
-                    fname=fname,
-                    selected=None,
-                )
+                dialog = XDFStreamsDialog(self, rows, fname=fname)
                 if dialog.exec():
                     fs_new = None
                     gap_threshold = 0.0

--- a/tests/test_xdf_streams.py
+++ b/tests/test_xdf_streams.py
@@ -1,0 +1,78 @@
+# © MNELAB developers
+#
+# License: BSD (3-clause)
+
+import pytest
+from PySide6.QtCore import QItemSelectionModel
+
+from mnelab.dialogs.xdf_streams import XDFStreamsDialog
+
+
+@pytest.fixture
+def rows():
+    """Rows mirroring a typical XDF file with data, marker, and string streams."""
+    return [
+        [1, "Keyboard", "Markers", 1, "string", 0.0],  # classic marker
+        [2, "BrainAmpSeries-1", "EEG", 67, "float32", 256.0],  # data stream
+        [3, "BrainAmpSeries-1-Sampled-Markers", "sampledMarkers", 1, "string", 5000.0],
+        [4, "AudioCaptureWin", "Audio", 2, "float32", 44100.0],  # data stream
+    ]
+
+
+def test_all_rows_shown(qtbot, rows):
+    """Test that marker streams are included in the table, not filtered out."""
+    dialog = XDFStreamsDialog(None, rows, fname="x")
+    qtbot.addWidget(dialog)
+
+    assert dialog.view.rowCount() == len(rows)
+
+
+def test_all_streams_selected_by_default(qtbot, rows):
+    """Test that all streams (data and marker) are selected by default."""
+    dialog = XDFStreamsDialog(None, rows, fname="x")
+    qtbot.addWidget(dialog)
+
+    selected = set(dialog.selected_streams) | set(dialog.selected_markers)
+    assert selected == {row[0] for row in rows}
+    assert set(dialog.selected_streams) == {2, 4}
+    assert set(dialog.selected_markers) == {1, 3}
+
+
+def test_ok_disabled_with_only_markers_selected(qtbot, rows):
+    """Test that OK is disabled unless at least one non-marker stream is selected."""
+    dialog = XDFStreamsDialog(None, rows, fname="x")
+    qtbot.addWidget(dialog)
+
+    ok_button = dialog.buttonbox.button(dialog.buttonbox.StandardButton.Ok)
+
+    dialog.view.clearSelection()
+    selection_model = dialog.view.selectionModel()
+    for row in range(dialog.view.rowCount()):
+        if dialog._is_marker_row(row):
+            selection_model.select(
+                dialog.view.model().index(row, 0),
+                QItemSelectionModel.SelectionFlag.Select
+                | QItemSelectionModel.SelectionFlag.Rows,
+            )
+    assert not dialog.selected_streams
+    assert dialog.selected_markers
+    assert not ok_button.isEnabled()
+
+
+def test_ok_enabled_with_data_stream_selected(qtbot, rows):
+    """Test that OK is enabled once a non-marker stream is selected."""
+    dialog = XDFStreamsDialog(None, rows, fname="x")
+    qtbot.addWidget(dialog)
+
+    ok_button = dialog.buttonbox.button(dialog.buttonbox.StandardButton.Ok)
+    assert ok_button.isEnabled()
+
+
+def test_suggested_fs_ignores_marker_rows(qtbot, rows):
+    """Test that the suggested sampling rate is based on data streams only."""
+    dialog = XDFStreamsDialog(None, rows, fname="x")
+    qtbot.addWidget(dialog)
+
+    # data streams have sampling rates 256 (67 channels) and 44100 (2 channels); the
+    # marker stream at 5000 Hz (1 channel) must not skew the suggestion
+    assert dialog.fs_new.value() == 256.0


### PR DESCRIPTION
This fixes a regression where XDF marker streams were not shown in the selection dialog (and therefore no annotations were created). In addition to fixing this (i.e., including *all* streams in the dialog, including marker streams), all streams are now initially selected for import (instead of previously none).