### PR TITLE
Handle invalid bad channels files gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [UNRELEASED] · YYYY-MM-DD
+### 🔧 Fixed
+- Handle invalid files gracefully when importing bad channels ([#686](https://github.com/cbrnr/mnelab/pull/686) by [Clemens Brunner](https://github.com/cbrnr))
+
 ### 🌀 Changed
 - Use MNEXTEND's `resolve_streams()` and `read_bvrf_header()` instead of depending on PyXDF and PyBVRF directly ([#679](https://github.com/cbrnr/mnelab/pull/679) by [Clemens Brunner](https://github.com/cbrnr))
 

--- a/src/mnelab/mainwindow.py
+++ b/src/mnelab/mainwindow.py
@@ -51,7 +51,12 @@ from PySide6.QtWidgets import (
 from mnelab import IS_DEV_VERSION, __version__
 from mnelab.dialogs import *  # noqa: F403
 from mnelab.dialogs.channel_stats import ChannelStats
-from mnelab.model import InvalidAnnotationsError, LabelsNotFoundError, Model
+from mnelab.model import (
+    InvalidAnnotationsError,
+    InvalidBadChannelsError,
+    LabelsNotFoundError,
+    Model,
+)
 from mnelab.settings import SettingsDialog, read_settings, write_settings
 from mnelab.utils import (
     annotations_between_events,
@@ -876,6 +881,8 @@ class MainWindow(QMainWindow):
                 f(fname)
             except LabelsNotFoundError as e:
                 QMessageBox.critical(self, "Channel labels not found", str(e))
+            except InvalidBadChannelsError as e:
+                QMessageBox.critical(self, "Invalid bad channels", str(e))
             except InvalidAnnotationsError as e:
                 QMessageBox.critical(self, "Invalid annotations", str(e))
 

--- a/src/mnelab/model.py
+++ b/src/mnelab/model.py
@@ -29,6 +29,10 @@ class LabelsNotFoundError(Exception):
     pass
 
 
+class InvalidBadChannelsError(Exception):
+    pass
+
+
 class InvalidAnnotationsError(Exception):
     pass
 
@@ -404,16 +408,36 @@ class Model:
     @data_changed
     def import_bads(self, fname):
         """Import bad channels info from a CSV file."""
-        with open(fname) as f:
-            bads = f.read().replace(" ", "").strip().split(",")
-            unknown = set(bads) - set(self.current["data"].info["ch_names"])
-            if unknown:
-                raise LabelsNotFoundError(
-                    "The following imported channel labels are not contained in the "
-                    "data: " + ",".join(unknown)
-                )
-            else:
-                self.current["data"].info["bads"] = bads
+        try:
+            with open(fname) as f:
+                content = f.read()
+        except UnicodeDecodeError:
+            raise InvalidBadChannelsError(
+                "The file contains binary data and cannot be read as CSV."
+            )
+        # a valid file contains a single line with a comma-separated list of labels
+        lines = [line for line in content.splitlines() if line.strip()]
+        if len(lines) > 1:
+            raise InvalidBadChannelsError(
+                "Invalid bad channels file (expected a single line with a "
+                "comma-separated list of channel labels)."
+            )
+        bads = [label.strip() for label in content.replace(" ", "").split(",")]
+        bads = [label for label in bads if label]  # drop empty tokens
+        if not bads:
+            raise InvalidBadChannelsError(
+                "The file does not contain any channel labels."
+            )
+        unknown = sorted(set(bads) - set(self.current["data"].info["ch_names"]))
+        if unknown:
+            preview = ", ".join(unknown[:10])
+            if len(unknown) > 10:
+                preview += f", … ({len(unknown) - 10} more)"
+            raise LabelsNotFoundError(
+                "The following imported channel labels are not contained in the "
+                "data: " + preview
+            )
+        self.current["data"].info["bads"] = bads
 
     @data_changed
     def import_events(self, fname):


### PR DESCRIPTION
Instead of showing a potentially very long error message in a dialog that cannot be closed (because the OK button is too far down), show a sensible error message.